### PR TITLE
Remove null values from chart values

### DIFF
--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -13,44 +13,44 @@ export RELEASE := yes
 ifeq ($(RELEASE),yes)
     export CILIUM_BRANCH:=v1.14
     export PULL_POLICY:=IfNotPresent
-    export CILIUM_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/cilium
-    export CILIUM_OPERATOR_BASE_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/operator
-    export CLUSTERMESH_APISERVER_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/clustermesh-apiserver
-    export HUBBLE_RELAY_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/hubble-relay
-    export KVSTOREMESH_REPO:=${RELEASE_REGISTRY}/${RELEASE_ORG}/kvstoremesh
+    export CILIUM_REPO:=giantswarm/cilium
+    export CILIUM_OPERATOR_BASE_REPO:=giantswarm/cilium-operator
+    export CLUSTERMESH_APISERVER_REPO:=giantswarm/cilium-clustermesh-apiserver
+    export HUBBLE_RELAY_REPO:=giantswarm/hubble-relay
+    export KVSTOREMESH_REPO:=quay.io/cilium/kvstoremesh
 else
     export CILIUM_BRANCH:=main
     export PULL_POLICY:=Always
-    export CILIUM_REPO:=${CI_REGISTRY}/${CI_ORG}/cilium-ci
-    export CILIUM_OPERATOR_BASE_REPO:=${CI_REGISTRY}/${CI_ORG}/operator
+    export CILIUM_REPO:=${CI_ORG}/cilium-ci
+    export CILIUM_OPERATOR_BASE_REPO:=${CI_ORG}/operator
     export CILIUM_OPERATOR_SUFFIX=-ci
     export CILIUM_VERSION:=latest
-    export CLUSTERMESH_APISERVER_REPO:=${CI_REGISTRY}/${CI_ORG}/clustermesh-apiserver-ci
-    export HUBBLE_RELAY_REPO:=${CI_REGISTRY}/${CI_ORG}/hubble-relay-ci
-    export KVSTOREMESH_REPO:=${CI_REGISTRY}/${CI_ORG}/kvstoremesh-ci
+    export CLUSTERMESH_APISERVER_REPO:=${CI_ORG}/clustermesh-apiserver-ci
+    export HUBBLE_RELAY_REPO:=${CI_ORG}/hubble-relay-ci
+    export KVSTOREMESH_REPO:=${CI_ORG}/kvstoremesh-ci
 endif
 
 ifndef CILIUM_BRANCH
 $(error "CILIUM_BRANCH needs to be defined")
 endif
 
-export CERTGEN_REPO:=quay.io/cilium/certgen
-export CERTGEN_VERSION:=v0.1.9
+export CERTGEN_REPO:=giantswarm/cilium-certgen
+export CERTGEN_VERSION:=v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f
 export CERTGEN_DIGEST:=sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f
 
-export CILIUM_ETCD_OPERATOR_REPO:=quay.io/cilium/cilium-etcd-operator
-export CILIUM_ETCD_OPERATOR_VERSION:=v2.0.7
+export CILIUM_ETCD_OPERATOR_REPO:=giantswarm/cilium-etcd-operator
+export CILIUM_ETCD_OPERATOR_VERSION:=v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
 export CILIUM_ETCD_OPERATOR_DIGEST:=sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc
-export CILIUM_NODEINIT_REPO:=quay.io/cilium/startup-script
+export CILIUM_NODEINIT_REPO:=giantswarm/cilium-startup-script
 export CILIUM_NODEINIT_VERSION:=62093c5c233ea914bfa26a10ba41f8780d9b737f
 
-export ETCD_REPO:=quay.io/coreos/etcd
-export ETCD_VERSION:=v3.5.4
+export ETCD_REPO:=giantswarm/etcd
+export ETCD_VERSION:=v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3
 export ETCD_DIGEST:=sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3
 
-export HUBBLE_UI_BACKEND_REPO:=quay.io/cilium/hubble-ui-backend
+export HUBBLE_UI_BACKEND_REPO:=giantswarm/hubble-ui-backend
 export HUBBLE_UI_BACKEND_VERSION:=v0.12.1
 export HUBBLE_UI_BACKEND_DIGEST:=sha256:1f86f3400827a0451e6332262467f894eeb7caf0eb8779bd951e2caa9d027cbe
-export HUBBLE_UI_FRONTEND_REPO:=quay.io/cilium/hubble-ui
+export HUBBLE_UI_FRONTEND_REPO:=giantswarm/hubble-ui
 export HUBBLE_UI_FRONTEND_VERSION:=v0.12.1
 export HUBBLE_UI_FRONTEND_DIGEST:=sha256:9e5f81ee747866480ea1ac4630eb6975ff9227f9782b7c93919c081c33f38267

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -86,7 +86,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.server.dataStorage.accessMode | string | `"ReadWriteOnce"` | Access mode of the SPIRE server data storage |
 | authentication.mutual.spire.install.server.dataStorage.enabled | bool | `true` | Enable SPIRE server data storage |
 | authentication.mutual.spire.install.server.dataStorage.size | string | `"1Gi"` | Size of the SPIRE server data storage |
-| authentication.mutual.spire.install.server.dataStorage.storageClass | string | `nil` | StorageClass of the SPIRE server data storage |
+| authentication.mutual.spire.install.server.dataStorage.storageClass | string | `""` | StorageClass of the SPIRE server data storage |
 | authentication.mutual.spire.install.server.image | string | `"ghcr.io/spiffe/spire-server:1.6.3@sha256:f4bc49fb0bd1d817a6c46204cc7ce943c73fb0a5496a78e0e4dc20c9a816ad7f"` | SPIRE server image |
 | authentication.mutual.spire.install.server.initContainers | list | `[]` | SPIRE server init containers |
 | authentication.mutual.spire.install.server.labels | object | `{}` | SPIRE server labels |
@@ -96,7 +96,7 @@ contributors across the globe, there is almost always someone available to help.
 | authentication.mutual.spire.install.server.service.type | string | `"ClusterIP"` | Service type for the SPIRE server service |
 | authentication.mutual.spire.install.server.serviceAccount | object | `{"create":true,"name":"spire-server"}` | SPIRE server service account |
 | authentication.mutual.spire.install.server.tolerations | list | `[]` | SPIRE server tolerations configuration ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
-| authentication.mutual.spire.serverAddress | string | `nil` | SPIRE server address used by Cilium Operator  If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format), Cilium Operator will resolve its address by looking up the clusterIP from Service resource.  Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081 |
+| authentication.mutual.spire.serverAddress | string | `""` | SPIRE server address used by Cilium Operator  If k8s Service DNS along with port number is used (e.g. <service-name>.<namespace>.svc(.*):<port-number> format), Cilium Operator will resolve its address by looking up the clusterIP from Service resource.  Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081 |
 | authentication.mutual.spire.trustDomain | string | `"spiffe.cilium"` | SPIFFE trust domain to use for fetching certificates |
 | authentication.queueSize | int | `1024` | Buffer size of the channel Cilium uses to receive authentication events from the signal map. |
 | authentication.rotatedIdentitiesQueueSize | int | `1024` | Buffer size of the channel Cilium uses to receive certificate expiration events from auth handlers. |
@@ -131,7 +131,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY to reduce reliance on iptables rules for implementing Layer 7 policy. |
 | bpf.vlanBypass | list | `[]` | Configure explicitly allowed VLAN id's for bpf logic bypass. [0] will allow all VLAN id's without any filtering. |
 | bpfClockProbe | bool | `false` | Enable BPF clock source probing for more efficient tick retrieval. |
-| certgen | object | `{"annotations":{"cronJob":{},"job":{}},"extraVolumeMounts":[],"extraVolumes":[],"image":{"digest":"sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/certgen","tag":"v0.1.9","useDigest":true},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
+| certgen | object | `{"annotations":{"cronJob":{},"job":{}},"extraVolumeMounts":[],"extraVolumes":[],"image":{"override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-certgen","tag":"v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"},"podLabels":{},"tolerations":[],"ttlSecondsAfterFinished":1800}` | Configure certificate generation for Hubble integration. If hubble.tls.auto.method=cronJob, these values are used for the Kubernetes CronJob which will be scheduled regularly to (re)generate any certificates not provided manually. |
 | certgen.annotations | object | `{"cronJob":{},"job":{}}` | Annotations to be added to the hubble-certgen initial Job and CronJob |
 | certgen.extraVolumeMounts | list | `[]` | Additional certgen volumeMounts. |
 | certgen.extraVolumes | list | `[]` | Additional certgen volumes. |
@@ -144,10 +144,11 @@ contributors across the globe, there is almost always someone available to help.
 | cgroup.hostRoot | string | `"/run/cilium/cgroupv2"` | Configure cgroup root where cgroup2 filesystem is mounted on the host (see also: `cgroup.autoMount`) |
 | cleanBpfState | bool | `false` | Clean all eBPF datapath state from the initContainer of the cilium-agent DaemonSet.  WARNING: Use with care! |
 | cleanState | bool | `false` | Clean all local Cilium state from the initContainer of the cilium-agent DaemonSet. Implies cleanBpfState: true.  WARNING: Use with care! |
+| cleanupKubeProxy | bool | `false` |  |
 | cluster.id | int | `0` | Unique ID of the cluster. Must be unique across all connected clusters and in the range of 1 to 255. Only required for Cluster Mesh, may be 0 if Cluster Mesh is not used. |
 | cluster.name | string | `"default"` | Name of the cluster. Only required for Cluster Mesh and mutual authentication with SPIRE. |
 | clustermesh.apiserver.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"clustermesh-apiserver"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for clustermesh.apiserver |
-| clustermesh.apiserver.etcd.image | object | `{"digest":"sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/coreos/etcd","tag":"v3.5.4","useDigest":true}` | Clustermesh API server etcd image. |
+| clustermesh.apiserver.etcd.image | object | `{"override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/etcd","tag":"v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"}` | Clustermesh API server etcd image. |
 | clustermesh.apiserver.etcd.init.resources | object | `{}` | Specifies the resources for etcd init container in the apiserver |
 | clustermesh.apiserver.etcd.resources | object | `{}` | Specifies the resources for etcd container in the apiserver |
 | clustermesh.apiserver.etcd.securityContext | object | `{}` | Security context to be added to clustermesh-apiserver etcd containers |
@@ -155,12 +156,12 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.extraEnv | list | `[]` | Additional clustermesh-apiserver environment variables. |
 | clustermesh.apiserver.extraVolumeMounts | list | `[]` | Additional clustermesh-apiserver volumeMounts. |
 | clustermesh.apiserver.extraVolumes | list | `[]` | Additional clustermesh-apiserver volumes. |
-| clustermesh.apiserver.image | object | `{"digest":"","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/clustermesh-apiserver","tag":"v1.14.5","useDigest":false}` | Clustermesh API server image. |
+| clustermesh.apiserver.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-clustermesh-apiserver","tag":"v1.14.5","useDigest":false}` | Clustermesh API server image. |
 | clustermesh.apiserver.kvstoremesh.enabled | bool | `false` | Enable KVStoreMesh. KVStoreMesh caches the information retrieved from the remote clusters in the local etcd instance. |
 | clustermesh.apiserver.kvstoremesh.extraArgs | list | `[]` | Additional KVStoreMesh arguments. |
 | clustermesh.apiserver.kvstoremesh.extraEnv | list | `[]` | Additional KVStoreMesh environment variables. |
 | clustermesh.apiserver.kvstoremesh.extraVolumeMounts | list | `[]` | Additional KVStoreMesh volumeMounts. |
-| clustermesh.apiserver.kvstoremesh.image | object | `{"digest":"","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/kvstoremesh","tag":"v1.14.5","useDigest":false}` | KVStoreMesh image. |
+| clustermesh.apiserver.kvstoremesh.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/kvstoremesh","tag":"v1.14.5","useDigest":false}` | KVStoreMesh image. |
 | clustermesh.apiserver.kvstoremesh.resources | object | `{}` | Resource requests and limits for the KVStoreMesh container |
 | clustermesh.apiserver.kvstoremesh.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]}}` | KVStoreMesh Security context |
 | clustermesh.apiserver.metrics.enabled | bool | `true` | Enables exporting apiserver metrics in OpenMetrics format. |
@@ -173,20 +174,19 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor clustermesh-apiserver |
 | clustermesh.apiserver.metrics.serviceMonitor.enabled | bool | `false` | Enable service monitor. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | clustermesh.apiserver.metrics.serviceMonitor.etcd.interval | string | `"10s"` | Interval for scrape metrics (etcd metrics) |
-| clustermesh.apiserver.metrics.serviceMonitor.etcd.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics) |
-| clustermesh.apiserver.metrics.serviceMonitor.etcd.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.etcd.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.etcd.relabelings | list | `[]` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics) |
 | clustermesh.apiserver.metrics.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics (apiserver metrics) |
 | clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.interval | string | `"10s"` | Interval for scrape metrics (KVStoreMesh metrics) |
-| clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics) |
-| clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.kvstoremesh.relabelings | list | `[]` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics) |
 | clustermesh.apiserver.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor clustermesh-apiserver |
-| clustermesh.apiserver.metrics.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics) |
-| clustermesh.apiserver.metrics.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics) |
+| clustermesh.apiserver.metrics.serviceMonitor.relabelings | list | `[]` | Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics) |
 | clustermesh.apiserver.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | clustermesh.apiserver.podAnnotations | object | `{}` | Annotations to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| clustermesh.apiserver.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
-| clustermesh.apiserver.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
+| clustermesh.apiserver.podDisruptionBudget.maxUnavailable | string | `"1"` | Maximum number/percentage of pods that may be made unavailable |
 | clustermesh.apiserver.podLabels | object | `{}` | Labels to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.podSecurityContext | object | `{}` | Security context to be added to clustermesh-apiserver pods |
 | clustermesh.apiserver.priorityClassName | string | `""` | The priority class to use for clustermesh-apiserver |
@@ -194,8 +194,8 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.apiserver.resources | object | `{}` | Resource requests and limits for the clustermesh-apiserver |
 | clustermesh.apiserver.securityContext | object | `{}` | Security context to be added to clustermesh-apiserver containers |
 | clustermesh.apiserver.service.annotations | object | `{}` | Annotations for the clustermesh-apiserver For GKE LoadBalancer, use annotation cloud.google.com/load-balancer-type: "Internal" For EKS LoadBalancer, use annotation service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0 |
-| clustermesh.apiserver.service.externalTrafficPolicy | string | `nil` | The externalTrafficPolicy of service used for apiserver access. |
-| clustermesh.apiserver.service.internalTrafficPolicy | string | `nil` | The internalTrafficPolicy of service used for apiserver access. |
+| clustermesh.apiserver.service.externalTrafficPolicy | string | `"Cluster"` | The externalTrafficPolicy of service used for apiserver access. |
+| clustermesh.apiserver.service.internalTrafficPolicy | string | `"Cluster"` | The internalTrafficPolicy of service used for apiserver access. |
 | clustermesh.apiserver.service.nodePort | int | `32379` | Optional port to use as the node port for apiserver access.  WARNING: make sure to configure a different NodePort in each cluster if kube-proxy replacement is enabled, as Cilium is currently affected by a known bug (#24692) when NodePorts are handled by the KPR implementation. If a service with the same NodePort exists both in the local and the remote cluster, all traffic originating from inside the cluster and targeting the corresponding NodePort will be redirected to a local backend, regardless of whether the destination node belongs to the local or the remote cluster. |
 | clustermesh.apiserver.service.type | string | `"NodePort"` | The type of service used for apiserver access. |
 | clustermesh.apiserver.tls.admin | object | `{"cert":"","key":""}` | base64 encoded PEM values for the clustermesh-apiserver admin certificate and private key. Used if 'auto' is not enabled. |
@@ -221,8 +221,8 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |
-| cni.chainingMode | string | `nil` | Configure chaining on top of other CNI plugins. Possible values:  - none  - aws-cni  - flannel  - generic-veth  - portmap |
-| cni.chainingTarget | string | `nil` | A CNI network name in to which the Cilium plugin should be added as a chained plugin. This will cause the agent to watch for a CNI network with this network name. When it is found, this will be used as the basis for Cilium's CNI configuration file. If this is set, it assumes a chaining mode of generic-veth. As a special case, a chaining mode of aws-cni implies a chainingTarget of aws-cni. |
+| cni.chainingMode | string | `""` | Configure chaining on top of other CNI plugins. Possible values:  - none  - aws-cni  - flannel  - generic-veth  - portmap |
+| cni.chainingTarget | string | `""` | A CNI network name in to which the Cilium plugin should be added as a chained plugin. This will cause the agent to watch for a CNI network with this network name. When it is found, this will be used as the basis for Cilium's CNI configuration file. If this is set, it assumes a chaining mode of generic-veth. As a special case, a chaining mode of aws-cni implies a chainingTarget of aws-cni. |
 | cni.confFileMountPath | string | `"/tmp/cni-configuration"` | Configure the path to where to mount the ConfigMap inside the agent pod. |
 | cni.confPath | string | `"/etc/cni/net.d"` | Configure the path to the CNI configuration directory on the host. |
 | cni.configMapKey | string | `"cni-config"` | Configure the key in the CNI ConfigMap to read the contents of the CNI configuration from. |
@@ -239,13 +239,16 @@ contributors across the globe, there is almost always someone available to help.
 | crdWaitTimeout | string | `"5m"` | Configure timeout in which Cilium will exit if CRDs are not available |
 | customCalls | object | `{"enabled":false}` | Tail call hooks for custom eBPF programs. |
 | customCalls.enabled | bool | `false` | Enable tail call hooks for custom eBPF programs. |
-| daemon.allowedConfigOverrides | string | `nil` | allowedConfigOverrides is a list of config-map keys that can be overridden. That is to say, if this value is set, config sources (excepting the first one) can only override keys in this list.  This takes precedence over blockedConfigOverrides.  By default, all keys may be overridden. To disable overrides, set this to "none" or change the configSources variable. |
-| daemon.blockedConfigOverrides | string | `nil` | blockedConfigOverrides is a list of config-map keys that may not be overridden. In other words, if any of these keys appear in a configuration source excepting the first one, they will be ignored  This is ignored if allowedConfigOverrides is set.  By default, all keys may be overridden. |
-| daemon.configSources | string | `nil` | Configure a custom list of possible configuration override sources The default is "config-map:cilium-config,cilium-node-config". For supported values, see the help text for the build-config subcommand. Note that this value should be a comma-separated string. |
+| daemon.allowedConfigOverrides | string | `""` | allowedConfigOverrides is a list of config-map keys that can be overridden. That is to say, if this value is set, config sources (excepting the first one) can only override keys in this list.  This takes precedence over blockedConfigOverrides.  By default, all keys may be overridden. To disable overrides, set this to "none" or change the configSources variable. |
+| daemon.blockedConfigOverrides | string | `""` | blockedConfigOverrides is a list of config-map keys that may not be overridden. In other words, if any of these keys appear in a configuration source excepting the first one, they will be ignored  This is ignored if allowedConfigOverrides is set.  By default, all keys may be overridden. |
+| daemon.configSources | string | `""` | Configure a custom list of possible configuration override sources The default is "config-map:cilium-config,cilium-node-config". For supported values, see the help text for the build-config subcommand. Note that this value should be a comma-separated string. |
 | daemon.runPath | string | `"/var/run/cilium"` | Configure where Cilium runtime state should be stored. |
-| dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for cilium-agent grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
+| dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":""}` | Grafana dashboards for cilium-agent grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | debug.enabled | bool | `false` | Enable debug logging |
-| debug.verbose | string | `nil` | Configure verbosity levels for debug logging This option is used to enable debug messages for operations related to such sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is for enabling debug messages emitted per request, message and connection.  Applicable values: - flow - kvstore - envoy - datapath - policy |
+| debug.verbose | string | `""` | Configure verbosity levels for debug logging This option is used to enable debug messages for operations related to such sub-system such as (e.g. kvstore, envoy, datapath or policy), and flow is for enabling debug messages emitted per request, message and connection.  Applicable values: - flow - kvstore - envoy - datapath - policy |
+| defaultPolicies.enabled | bool | `false` |  |
+| defaultPolicies.remove | bool | `false` |  |
+| defaultPolicies.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for default-policies job scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
 | disableEndpointCRD | bool | `false` | Disable the usage of CiliumEndpoint CRD. |
 | dnsPolicy | string | `""` | DNS policy for Cilium agent pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | dnsProxy.dnsRejectResponseCode | string | `"refused"` | DNS response code for rejecting DNS requests, available options are '[nameError refused]'. |
@@ -260,6 +263,7 @@ contributors across the globe, there is almost always someone available to help.
 | egressGateway | object | `{"enabled":false,"installRoutes":false,"reconciliationTriggerInterval":"1s"}` | Enables egress gateway to redirect and SNAT the traffic that leaves the cluster. |
 | egressGateway.installRoutes | bool | `false` | Install egress gateway IP rules and routes in order to properly steer egress gateway traffic to the correct ENI interface |
 | egressGateway.reconciliationTriggerInterval | string | `"1s"` | Time between triggers of egress gateway state reconciliations |
+| eksMode | bool | `false` |  |
 | enableCiliumEndpointSlice | bool | `false` | Enable CiliumEndpointSlice feature. |
 | enableCnpStatusUpdates | bool | `false` | Whether to enable CNP status updates. |
 | enableCriticalPriorityClass | bool | `true` | Explicitly enable or disable priority class. .Capabilities.KubeVersion is unsettable in `helm template` calls, it depends on k8s libraries version that Helm was compiled against. This option allows to explicitly disable setting the priority class, which is useful for rendering charts for gke clusters in advance. |
@@ -302,7 +306,7 @@ contributors across the globe, there is almost always someone available to help.
 | eni.updateEC2AdapterLimitViaAPI | bool | `true` | Update ENI Adapter limits from the EC2 API |
 | envoy.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium-envoy"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-envoy. |
 | envoy.connectTimeoutSeconds | int | `2` | Time in seconds after which a TCP connection attempt times out |
-| envoy.dnsPolicy | string | `nil` | DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
+| envoy.dnsPolicy | string | `""` | DNS policy for Cilium envoy pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | envoy.enabled | bool | `false` | Enable Envoy Proxy in standalone DaemonSet. |
 | envoy.extraArgs | list | `[]` | Additional envoy container arguments. |
 | envoy.extraContainers | list | `[]` | Additional containers added to the cilium Envoy DaemonSet. |
@@ -312,7 +316,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:992998398dadfff7117bfa9fdb7c9474fefab7f0237263f7c8114e106c67baca","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:992998398dadfff7117bfa9fdb7c9474fefab7f0237263f7c8114e106c67baca","override":"","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |
@@ -323,14 +327,14 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.podAnnotations | object | `{}` | Annotations to be added to envoy pods |
 | envoy.podLabels | object | `{}` | Labels to be added to envoy pods |
 | envoy.podSecurityContext | object | `{}` | Security Context for cilium-envoy pods. |
-| envoy.priorityClassName | string | `nil` | The priority class to use for cilium-envoy. |
+| envoy.priorityClassName | string | `""` | The priority class to use for cilium-envoy. |
 | envoy.prometheus.enabled | bool | `true` | Enable prometheus metrics for cilium-envoy |
 | envoy.prometheus.port | string | `"9964"` | Serve prometheus metrics for cilium-envoy on the configured port |
 | envoy.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-envoy |
 | envoy.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | envoy.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | envoy.prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-envoy |
-| envoy.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-envoy |
+| envoy.prometheus.serviceMonitor.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor cilium-envoy |
 | envoy.prometheus.serviceMonitor.relabelings | list | `[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]` | Relabeling configs for the ServiceMonitor cilium-envoy |
 | envoy.readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |
 | envoy.readinessProbe.periodSeconds | int | `30` | interval between checks of the readiness probe |
@@ -354,13 +358,12 @@ contributors across the globe, there is almost always someone available to help.
 | etcd.extraArgs | list | `[]` | Additional cilium-etcd-operator container arguments. |
 | etcd.extraVolumeMounts | list | `[]` | Additional cilium-etcd-operator volumeMounts. |
 | etcd.extraVolumes | list | `[]` | Additional cilium-etcd-operator volumes. |
-| etcd.image | object | `{"digest":"sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-etcd-operator","tag":"v2.0.7","useDigest":true}` | cilium-etcd-operator image. |
+| etcd.image | object | `{"override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-etcd-operator","tag":"v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc"}` | cilium-etcd-operator image. |
 | etcd.k8sService | bool | `false` | If etcd is behind a k8s service set this option to true so that Cilium does the service translation automatically without requiring a DNS to be running. |
 | etcd.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-etcd-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | etcd.podAnnotations | object | `{}` | Annotations to be added to cilium-etcd-operator pods |
 | etcd.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| etcd.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
-| etcd.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
+| etcd.podDisruptionBudget.maxUnavailable | string | `"1"` | Maximum number/percentage of pods that may be made unavailable |
 | etcd.podLabels | object | `{}` | Labels to be added to cilium-etcd-operator pods |
 | etcd.podSecurityContext | object | `{}` | Security context to be added to cilium-etcd-operator pods |
 | etcd.priorityClassName | string | `""` | The priority class to use for cilium-etcd-operator |
@@ -378,6 +381,15 @@ contributors across the globe, there is almost always someone available to help.
 | extraContainers | list | `[]` | Additional containers added to the cilium DaemonSet. |
 | extraEnv | list | `[]` | Additional agent container environment variables. |
 | extraHostPathMounts | list | `[]` | Additional agent hostPath mounts. |
+| extraPolicies.allowEgressToCoreDNS.enabled | bool | `false` |  |
+| extraPolicies.allowEgressToCoreDNS.namespaces[0] | string | `"giantswarm"` |  |
+| extraPolicies.allowEgressToCoreDNS.namespaces[1] | string | `"kube-system"` |  |
+| extraPolicies.allowEgressToProxy.enabled | bool | `false` |  |
+| extraPolicies.allowEgressToProxy.httpProxy | string | `""` |  |
+| extraPolicies.allowEgressToProxy.httpsProxy | string | `""` |  |
+| extraPolicies.allowEgressToProxy.namespaces[0] | string | `"giantswarm"` |  |
+| extraPolicies.allowEgressToProxy.namespaces[1] | string | `"kube-system"` |  |
+| extraPolicies.tolerations[0].operator | string | `"Exists"` |  |
 | extraVolumeMounts | list | `[]` | Additional agent volumeMounts. |
 | extraVolumes | list | `[]` | Additional agent volumes. |
 | gatewayAPI.enabled | bool | `false` | Enable support for Gateway API in cilium This will automatically set enable-envoy-config as well. |
@@ -386,6 +398,7 @@ contributors across the globe, there is almost always someone available to help.
 | gatewayAPI.secretsNamespace.name | string | `"cilium-secrets"` | Name of Gateway API secret namespace. |
 | gatewayAPI.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
 | gke.enabled | bool | `false` | Enable Google Kubernetes Engine integration |
+| global.podSecurityStandards.enforced | bool | `false` |  |
 | healthChecking | bool | `true` | Enable connectivity health checking. |
 | healthPort | int | `9879` | TCP port for the agent health API. This is not the port for cilium-health. |
 | highScaleIPcache | object | `{"enabled":false}` | EnableHighScaleIPcache enables the special ipcache mode for high scale clusters. The ipcache content will be reduced to the strict minimum and traffic will be encapsulated to carry security identities. |
@@ -395,60 +408,59 @@ contributors across the globe, there is almost always someone available to help.
 | hostPort.enabled | bool | `false` | Enable hostPort service support. |
 | hubble.enabled | bool | `true` | Enable Hubble (true by default). |
 | hubble.listenAddress | string | `":4244"` | An additional address for Hubble to listen to. Set this field ":4244" if you are enabling Hubble Relay, as it assumes that Hubble is listening on port 4244. |
-| hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null},"enableOpenMetrics":false,"enabled":null,"port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
-| hubble.metrics.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for hubble grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
+| hubble.metrics | object | `{"dashboards":{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":""},"enableOpenMetrics":false,"enabled":"","port":9965,"serviceAnnotations":{},"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":[],"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]}}` | Hubble metrics configuration. See https://docs.cilium.io/en/stable/observability/metrics/#hubble-metrics for more comprehensive documentation about Hubble metrics. |
+| hubble.metrics.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":""}` | Grafana dashboards for hubble grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | hubble.metrics.enableOpenMetrics | bool | `false` | Enables exporting hubble metrics in OpenMetrics format. |
-| hubble.metrics.enabled | string | `nil` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
+| hubble.metrics.enabled | string | `""` | Configures the list of metrics to collect. If empty or null, metrics are disabled. Example:    enabled:   - dns:query;ignoreAAAA   - drop   - tcp   - flow   - icmp   - http  You can specify the list of metrics from the helm CLI:    --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"  |
 | hubble.metrics.port | int | `9965` | Configure the port the hubble metric server listens on. |
 | hubble.metrics.serviceAnnotations | object | `{}` | Annotations to be added to hubble-metrics service. |
 | hubble.metrics.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.enabled | bool | `false` | Create ServiceMonitor resources for Prometheus Operator. This requires the prometheus CRDs to be available. ref: https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.metrics.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | hubble.metrics.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble |
-| hubble.metrics.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble |
+| hubble.metrics.serviceMonitor.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor hubble |
 | hubble.metrics.serviceMonitor.relabelings | list | `[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]` | Relabeling configs for the ServiceMonitor hubble |
 | hubble.peerService.clusterDomain | string | `"cluster.local"` | The cluster domain to use to query the Hubble Peer service. It should be the local cluster. |
 | hubble.peerService.targetPort | int | `4244` | Target Port for the Peer service, must match the hubble.listenAddress' port. |
 | hubble.preferIpv6 | bool | `false` | Whether Hubble should prefer to announce IPv6 or IPv4 addresses if both are available. |
 | hubble.relay.affinity | object | `{"podAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"k8s-app":"cilium"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for hubble-replay |
-| hubble.relay.dialTimeout | string | `nil` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
-| hubble.relay.enabled | bool | `false` | Enable Hubble Relay (requires hubble.enabled=true) |
+| hubble.relay.dialTimeout | string | `""` | Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s"). |
+| hubble.relay.enabled | bool | `true` | Enable Hubble Relay (requires hubble.enabled=true) |
 | hubble.relay.extraEnv | list | `[]` | Additional hubble-relay environment variables. |
 | hubble.relay.extraVolumeMounts | list | `[]` | Additional hubble-relay volumeMounts. |
 | hubble.relay.extraVolumes | list | `[]` | Additional hubble-relay volumes. |
 | hubble.relay.gops.enabled | bool | `true` | Enable gops for hubble-relay |
 | hubble.relay.gops.port | int | `9893` | Configure gops listen port for hubble-relay |
-| hubble.relay.image | object | `{"digest":"","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-relay","tag":"v1.14.5","useDigest":false}` | Hubble-relay container image. |
+| hubble.relay.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-relay","tag":"v1.14.5","useDigest":false}` | Hubble-relay container image. |
 | hubble.relay.listenHost | string | `""` | Host to listen to. Specify an empty string to bind to all the interfaces. |
 | hubble.relay.listenPort | string | `"4245"` | Port to listen to. |
 | hubble.relay.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | hubble.relay.podAnnotations | object | `{}` | Annotations to be added to hubble-relay pods |
 | hubble.relay.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| hubble.relay.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
-| hubble.relay.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
+| hubble.relay.podDisruptionBudget.maxUnavailable | string | `"1"` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.relay.podLabels | object | `{}` | Labels to be added to hubble-relay pods |
 | hubble.relay.podSecurityContext | object | `{"fsGroup":65532}` | hubble-relay pod security context |
 | hubble.relay.pprof.address | string | `"localhost"` | Configure pprof listen address for hubble-relay |
 | hubble.relay.pprof.enabled | bool | `false` | Enable pprof for hubble-relay |
 | hubble.relay.pprof.port | int | `6062` | Configure pprof listen port for hubble-relay |
 | hubble.relay.priorityClassName | string | `""` | The priority class to use for hubble-relay |
-| hubble.relay.prometheus | object | `{"enabled":false,"port":9966,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for hubble-relay on the configured port at /metrics |
+| hubble.relay.prometheus | object | `{"enabled":true,"port":9966,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":[],"relabelings":[]}}` | Enable prometheus metrics for hubble-relay on the configured port at /metrics |
 | hubble.relay.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor hubble-relay |
 | hubble.relay.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | hubble.relay.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | hubble.relay.prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor hubble-relay |
-| hubble.relay.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor hubble-relay |
-| hubble.relay.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor hubble-relay |
+| hubble.relay.prometheus.serviceMonitor.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor hubble-relay |
+| hubble.relay.prometheus.serviceMonitor.relabelings | list | `[]` | Relabeling configs for the ServiceMonitor hubble-relay |
 | hubble.relay.replicas | int | `1` | Number of replicas run for the hubble-relay deployment. |
 | hubble.relay.resources | object | `{}` | Specifies the resources for the hubble-relay pods |
-| hubble.relay.retryTimeout | string | `nil` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
+| hubble.relay.retryTimeout | string | `""` | Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s"). |
 | hubble.relay.rollOutPods | bool | `false` | Roll out Hubble Relay pods automatically when configmap is updated. |
 | hubble.relay.securityContext | object | `{"capabilities":{"drop":["ALL"]},"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532}` | hubble-relay container security context |
 | hubble.relay.service | object | `{"nodePort":31234,"type":"ClusterIP"}` | hubble-relay service configuration. |
 | hubble.relay.service.nodePort | int | `31234` | - The port to use when the service type is set to NodePort. |
 | hubble.relay.service.type | string | `"ClusterIP"` | - The type of service used for Hubble Relay access, either ClusterIP or NodePort. |
-| hubble.relay.sortBufferDrainTimeout | string | `nil` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
-| hubble.relay.sortBufferLenMax | string | `nil` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
+| hubble.relay.sortBufferDrainTimeout | string | `""` | When the per-request flows sort buffer is not full, a flow is drained every time this timeout is reached (only affects requests in follow-mode) (e.g. "1s"). |
+| hubble.relay.sortBufferLenMax | int | `100` | Max number of flows that can be buffered for sorting before being sent to the client (per request) (e.g. 100). |
 | hubble.relay.terminationGracePeriodSeconds | int | `1` | Configure termination grace period for hubble relay Deployment. |
 | hubble.relay.tls | object | `{"client":{"cert":"","key":""},"server":{"cert":"","enabled":false,"extraDnsNames":[],"extraIpAddresses":[],"key":"","mtls":false}}` | TLS configuration for Hubble Relay |
 | hubble.relay.tls.client | object | `{"cert":"","key":""}` | base64 encoded PEM values for the hubble-relay client certificate and private key This keypair is presented to Hubble server instances for mTLS authentication and is required when hubble.tls.enabled is true. These values need to be set manually if hubble.tls.auto.enabled is false. |
@@ -475,15 +487,15 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.backend.extraEnv | list | `[]` | Additional hubble-ui backend environment variables. |
 | hubble.ui.backend.extraVolumeMounts | list | `[]` | Additional hubble-ui backend volumeMounts. |
 | hubble.ui.backend.extraVolumes | list | `[]` | Additional hubble-ui backend volumes. |
-| hubble.ui.backend.image | object | `{"digest":"sha256:1f86f3400827a0451e6332262467f894eeb7caf0eb8779bd951e2caa9d027cbe","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui-backend","tag":"v0.12.1","useDigest":true}` | Hubble-ui backend image. |
+| hubble.ui.backend.image | object | `{"digest":"sha256:1f86f3400827a0451e6332262467f894eeb7caf0eb8779bd951e2caa9d027cbe","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-ui-backend","tag":"v0.12.1","useDigest":false}` | Hubble-ui backend image. |
 | hubble.ui.backend.resources | object | `{}` | Resource requests and limits for the 'backend' container of the 'hubble-ui' deployment. |
 | hubble.ui.backend.securityContext | object | `{}` | Hubble-ui backend security context. |
 | hubble.ui.baseUrl | string | `"/"` | Defines base url prefix for all hubble-ui http requests. It needs to be changed in case if ingress for hubble-ui is configured under some sub-path. Trailing `/` is required for custom path, ex. `/service-map/` |
-| hubble.ui.enabled | bool | `false` | Whether to enable the Hubble UI. |
+| hubble.ui.enabled | bool | `true` | Whether to enable the Hubble UI. |
 | hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
 | hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
 | hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
-| hubble.ui.frontend.image | object | `{"digest":"sha256:9e5f81ee747866480ea1ac4630eb6975ff9227f9782b7c93919c081c33f38267","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui","tag":"v0.12.1","useDigest":true}` | Hubble-ui frontend image. |
+| hubble.ui.frontend.image | object | `{"digest":"sha256:9e5f81ee747866480ea1ac4630eb6975ff9227f9782b7c93919c081c33f38267","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/hubble-ui","tag":"v0.12.1","useDigest":false}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.securityContext | object | `{}` | Hubble-ui frontend security context. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |
@@ -491,8 +503,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | hubble.ui.podAnnotations | object | `{}` | Annotations to be added to hubble-ui pods |
 | hubble.ui.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| hubble.ui.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
-| hubble.ui.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
+| hubble.ui.podDisruptionBudget.maxUnavailable | string | `"1"` | Maximum number/percentage of pods that may be made unavailable |
 | hubble.ui.podLabels | object | `{}` | Labels to be added to hubble-ui pods |
 | hubble.ui.priorityClassName | string | `""` | The priority class to use for hubble-ui |
 | hubble.ui.replicas | int | `1` | The number of replicas of Hubble UI to deploy. |
@@ -510,11 +521,11 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.updateStrategy | object | `{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}` | hubble-ui update strategy. |
 | identityAllocationMode | string | `"crd"` | Method to use for identity allocation (`crd` or `kvstore`). |
 | identityChangeGracePeriod | string | `"5s"` | Time to wait before using new identity on endpoint identity change. |
-| image | object | `{"digest":"","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.14.5","useDigest":false}` | Agent container image. |
-| imagePullSecrets | string | `nil` | Configure image pull secrets for pulling container images |
+| image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","registry":"gsoci.azurecr.io","repository":"giantswarm/cilium","tag":"v1.14.5","useDigest":false}` | Agent container image. |
+| imagePullSecrets | list | `[]` | Configure image pull secrets for pulling container images |
 | ingressController.default | bool | `false` | Set cilium ingress controller to be the default ingress controller This will let cilium ingress controller route entries without ingress class set |
-| ingressController.defaultSecretName | string | `nil` | Default secret name for ingresses without .spec.tls[].secretName set. |
-| ingressController.defaultSecretNamespace | string | `nil` | Default secret namespace for ingresses without .spec.tls[].secretName set. |
+| ingressController.defaultSecretName | string | `""` | Default secret name for ingresses without .spec.tls[].secretName set. |
+| ingressController.defaultSecretNamespace | string | `""` | Default secret namespace for ingresses without .spec.tls[].secretName set. |
 | ingressController.enabled | bool | `false` | Enable cilium ingress controller This will automatically set enable-envoy-config as well. |
 | ingressController.enforceHttps | bool | `true` | Enforce https for host having matching TLS host in Ingress. Incoming traffic to http listener will return 308 http error code with respective location in header. |
 | ingressController.ingressLBAnnotationPrefixes | list | `["service.beta.kubernetes.io","service.kubernetes.io","cloud.google.com"]` | IngressLBAnnotations are the annotation prefixes, which are used to filter annotations to propagate from Ingress to the Load Balancer service |
@@ -523,15 +534,15 @@ contributors across the globe, there is almost always someone available to help.
 | ingressController.secretsNamespace.create | bool | `true` | Create secrets namespace for Ingress. |
 | ingressController.secretsNamespace.name | string | `"cilium-secrets"` | Name of Ingress secret namespace. |
 | ingressController.secretsNamespace.sync | bool | `true` | Enable secret sync, which will make sure all TLS secrets used by Ingress are synced to secretsNamespace.name. If disabled, TLS secrets must be maintained externally. |
-| ingressController.service | object | `{"allocateLoadBalancerNodePorts":null,"annotations":{},"insecureNodePort":null,"labels":{},"loadBalancerClass":null,"loadBalancerIP":null,"name":"cilium-ingress","secureNodePort":null,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
-| ingressController.service.allocateLoadBalancerNodePorts | string | `nil` | Configure if node port allocation is required for LB service ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation |
+| ingressController.service | object | `{"allocateLoadBalancerNodePorts":true,"annotations":{},"insecureNodePort":0,"labels":{},"loadBalancerClass":"","loadBalancerIP":"","name":"cilium-ingress","secureNodePort":0,"type":"LoadBalancer"}` | Load-balancer service in shared mode. This is a single load-balancer service for all Ingress resources. |
+| ingressController.service.allocateLoadBalancerNodePorts | bool | `true` | Configure if node port allocation is required for LB service ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation |
 | ingressController.service.annotations | object | `{}` | Annotations to be added for the shared LB service |
-| ingressController.service.insecureNodePort | string | `nil` | Configure a specific nodePort for insecure HTTP traffic on the shared LB service |
+| ingressController.service.insecureNodePort | int | `0` | Configure a specific nodePort for insecure HTTP traffic on the shared LB service |
 | ingressController.service.labels | object | `{}` | Labels to be added for the shared LB service |
-| ingressController.service.loadBalancerClass | string | `nil` | Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+) |
-| ingressController.service.loadBalancerIP | string | `nil` | Configure a specific loadBalancerIP on the shared LB service |
+| ingressController.service.loadBalancerClass | string | `""` | Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+) |
+| ingressController.service.loadBalancerIP | string | `""` | Configure a specific loadBalancerIP on the shared LB service |
 | ingressController.service.name | string | `"cilium-ingress"` | Service name |
-| ingressController.service.secureNodePort | string | `nil` | Configure a specific nodePort for secure HTTPS traffic on the shared LB service |
+| ingressController.service.secureNodePort | int | `0` | Configure a specific nodePort for secure HTTPS traffic on the shared LB service |
 | ingressController.service.type | string | `"LoadBalancer"` | Service type for the shared LB service |
 | initResources | object | `{}` | resources & limits for the agent init containers |
 | installNoConntrackIptablesRules | bool | `false` | Install Iptables rules to skip netfilter connection tracking on all pod traffic. This option is only effective when Cilium is running in direct routing and full KPR mode. Moreover, this option cannot be enabled when Cilium is running in a managed Kubernetes environment or in a chained CNI setup. |
@@ -543,8 +554,8 @@ contributors across the globe, there is almost always someone available to help.
 | ipam.operator.clusterPoolIPv4PodCIDRList | list | `["10.0.0.0/8"]` | IPv4 CIDR list range to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6MaskSize | int | `120` | IPv6 CIDR mask size to delegate to individual nodes for IPAM. |
 | ipam.operator.clusterPoolIPv6PodCIDRList | list | `["fd00::/104"]` | IPv6 CIDR list range to delegate to individual nodes for IPAM. |
-| ipam.operator.externalAPILimitBurstSize | string | `20` | The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity. |
-| ipam.operator.externalAPILimitQPS | string | `4.0` | The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity. |
+| ipam.operator.externalAPILimitBurstSize | int | `20` | The maximum burst size when rate limiting access to external APIs. Also known as the token bucket capacity. |
+| ipam.operator.externalAPILimitQPS | float | `4.0` | The maximum queries per second when rate limiting access to external APIs. Also known as the bucket refill rate, which is used to refill the bucket up to the burst size capacity. |
 | ipv4.enabled | bool | `true` | Enable IPv4 support. |
 | ipv4NativeRoutingCIDR | string | `""` | Allows to explicitly specify the IPv4 CIDR for native routing. When specified, Cilium assumes networking for this CIDR is preconfigured and hands traffic destined for that range to the Linux network stack without applying any SNAT. Generally speaking, specifying a native routing CIDR implies that Cilium can depend on the underlying networking stack to route packets to their destination. To offer a concrete example, if Cilium is configured to use direct routing and the Kubernetes CIDR is included in the native routing CIDR, the user must configure the routes to reach pods, either manually or by setting the auto-direct-node-routes flag. |
 | ipv6.enabled | bool | `false` | Enable IPv6 support. |
@@ -568,6 +579,7 @@ contributors across the globe, there is almost always someone available to help.
 | l2podAnnouncements.enabled | bool | `false` | Enable L2 pod announcements |
 | l2podAnnouncements.interface | string | `"eth0"` | Interface used for sending Gratuitous ARP pod announcements |
 | l7Proxy | bool | `true` | Enable Layer 7 network policy. |
+| labels | string | `"k8s:!.*/enforce k8s:!.*fluxcd.io/.* k8s:!.*kubernetes.io/managed-by.* k8s:!controller-uid k8s:!job-name"` |  |
 | livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | loadBalancer | object | `{"l7":{"algorithm":"round_robin","backend":"disabled","ports":[]}}` | Configure service load balancing |
@@ -575,7 +587,7 @@ contributors across the globe, there is almost always someone available to help.
 | loadBalancer.l7.algorithm | string | `"round_robin"` | Default LB algorithm The default LB algorithm to be used for services, which can be overridden by the service annotation (e.g. service.cilium.io/lb-l7-algorithm) Applicable values: round_robin, least_request, random |
 | loadBalancer.l7.backend | string | `"disabled"` | Enable L7 service load balancing via envoy proxy. The request to a k8s service, which has specific annotation e.g. service.cilium.io/lb-l7, will be forwarded to the local backend proxy to be load balanced to the service endpoints. Please refer to docs for supported annotations for more configuration.  Applicable values:   - envoy: Enable L7 load balancing via envoy proxy. This will automatically set enable-envoy-config as well.   - disabled: Disable L7 load balancing by way of service annotation. |
 | loadBalancer.l7.ports | list | `[]` | List of ports from service to be automatically redirected to above backend. Any service exposing one of these ports will be automatically redirected. Fine-grained control can be achieved by using the service annotation. |
-| localRedirectPolicy | bool | `false` | Enable Local Redirect Policy. |
+| localRedirectPolicy | bool | `true` | Enable Local Redirect Policy. |
 | logSystemLoad | bool | `false` | Enables periodic logging of system load |
 | maglev | object | `{}` | Configure maglev consistent hashing |
 | monitor | object | `{"enabled":false}` | cilium-monitor sidecar. |
@@ -595,7 +607,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.extraEnv | list | `[]` | Additional nodeinit environment variables. |
 | nodeinit.extraVolumeMounts | list | `[]` | Additional nodeinit volumeMounts. |
 | nodeinit.extraVolumes | list | `[]` | Additional nodeinit volumes. |
-| nodeinit.image | object | `{"override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/startup-script","tag":"62093c5c233ea914bfa26a10ba41f8780d9b737f"}` | node-init image. |
+| nodeinit.image | object | `{"override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-startup-script","tag":"62093c5c233ea914bfa26a10ba41f8780d9b737f"}` | node-init image. |
 | nodeinit.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for nodeinit pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | nodeinit.podAnnotations | object | `{}` | Annotations to be added to node-init pods. |
 | nodeinit.podLabels | object | `{}` | Labels to be added to node-init pods. |
@@ -607,7 +619,7 @@ contributors across the globe, there is almost always someone available to help.
 | nodeinit.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for nodeinit scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
 | nodeinit.updateStrategy | object | `{"type":"RollingUpdate"}` | node-init update strategy |
 | operator.affinity | object | `{"podAntiAffinity":{"requiredDuringSchedulingIgnoredDuringExecution":[{"labelSelector":{"matchLabels":{"io.cilium/app":"operator"}},"topologyKey":"kubernetes.io/hostname"}]}}` | Affinity for cilium-operator |
-| operator.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":null}` | Grafana dashboards for cilium-operator grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
+| operator.dashboards | object | `{"annotations":{},"enabled":false,"label":"grafana_dashboard","labelValue":"1","namespace":""}` | Grafana dashboards for cilium-operator grafana can import dashboards based on the label and value ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards |
 | operator.dnsPolicy | string | `""` | DNS policy for Cilium operator pods. Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy |
 | operator.enabled | bool | `true` | Enable the cilium-operator component (required). |
 | operator.endpointGCInterval | string | `"5m0s"` | Interval for endpoint garbage collection. |
@@ -618,33 +630,32 @@ contributors across the globe, there is almost always someone available to help.
 | operator.extraVolumes | list | `[]` | Additional cilium-operator volumes. |
 | operator.identityGCInterval | string | `"15m0s"` | Interval for identity garbage collection. |
 | operator.identityHeartbeatTimeout | string | `"30m0s"` | Timeout for identity heartbeats. |
-| operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/operator","suffix":"","tag":"v1.14.5","useDigest":false}` | cilium-operator image. |
+| operator.image | object | `{"alibabacloudDigest":"","awsDigest":"","azureDigest":"","genericDigest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-operator","suffix":"","tag":"v1.14.5","useDigest":false}` | cilium-operator image. |
 | operator.nodeGCInterval | string | `"5m0s"` | Interval for cilium node garbage collection. |
 | operator.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for cilium-operator pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | operator.podAnnotations | object | `{}` | Annotations to be added to cilium-operator pods |
-| operator.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| operator.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
-| operator.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
+| operator.podDisruptionBudget.enabled | bool | `true` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
+| operator.podDisruptionBudget.maxUnavailable | string | `"1"` | Maximum number/percentage of pods that may be made unavailable |
 | operator.podLabels | object | `{}` | Labels to be added to cilium-operator pods |
 | operator.podSecurityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.pprof.address | string | `"localhost"` | Configure pprof listen address for cilium-operator |
 | operator.pprof.enabled | bool | `false` | Enable pprof for cilium-operator |
 | operator.pprof.port | int | `6061` | Configure pprof listen port for cilium-operator |
 | operator.priorityClassName | string | `""` | The priority class to use for cilium-operator |
-| operator.prometheus | object | `{"enabled":false,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":null}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
+| operator.prometheus | object | `{"enabled":true,"port":9963,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":[],"relabelings":[]}}` | Enable prometheus metrics for cilium-operator on the configured port at /metrics |
 | operator.prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-operator |
 | operator.prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | operator.prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | operator.prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-operator |
-| operator.prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-operator |
-| operator.prometheus.serviceMonitor.relabelings | string | `nil` | Relabeling configs for the ServiceMonitor cilium-operator |
+| operator.prometheus.serviceMonitor.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor cilium-operator |
+| operator.prometheus.serviceMonitor.relabelings | list | `[]` | Relabeling configs for the ServiceMonitor cilium-operator |
 | operator.removeNodeTaints | bool | `true` | Remove Cilium node taint from Kubernetes nodes that have a healthy Cilium pod running. |
 | operator.replicas | int | `2` | Number of replicas to run for the cilium-operator deployment |
 | operator.resources | object | `{}` | cilium-operator resource limits & requests ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | operator.rollOutPods | bool | `false` | Roll out cilium-operator pods automatically when configmap is updated. |
 | operator.securityContext | object | `{}` | Security context to be added to cilium-operator pods |
 | operator.setNodeNetworkStatus | bool | `true` | Set Node condition NetworkUnavailable to 'false' with the reason 'CiliumIsUp' for nodes that have a healthy Cilium pod. |
-| operator.setNodeTaints | string | same as removeNodeTaints | Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider. |
+| operator.setNodeTaints | bool | same as removeNodeTaints | Taint nodes where Cilium is scheduled but not running. This prevents pods from being scheduled to nodes where Cilium is not the default CNI provider. |
 | operator.skipCNPStatusStartupClean | bool | `false` | Skip CNP node status clean up at operator startup. |
 | operator.skipCRDCreation | bool | `false` | Skip CRDs creation for cilium-operator |
 | operator.tolerations | list | `[{"operator":"Exists"}]` | Node tolerations for cilium-operator scheduling to nodes with taints ref: https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/ |
@@ -665,12 +676,11 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.extraEnv | list | `[]` | Additional preflight environment variables. |
 | preflight.extraVolumeMounts | list | `[]` | Additional preflight volumeMounts. |
 | preflight.extraVolumes | list | `[]` | Additional preflight volumes. |
-| preflight.image | object | `{"digest":"","override":null,"pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium","tag":"v1.14.5","useDigest":false}` | Cilium pre-flight image. |
+| preflight.image | object | `{"digest":"","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium","tag":"v1.14.5","useDigest":false}` | Cilium pre-flight image. |
 | preflight.nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Node labels for preflight pod assignment ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector |
 | preflight.podAnnotations | object | `{}` | Annotations to be added to preflight pods |
 | preflight.podDisruptionBudget.enabled | bool | `false` | enable PodDisruptionBudget ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/ |
-| preflight.podDisruptionBudget.maxUnavailable | int | `1` | Maximum number/percentage of pods that may be made unavailable |
-| preflight.podDisruptionBudget.minAvailable | string | `nil` | Minimum number/percentage of pods that should remain scheduled. When it's set, maxUnavailable must be disabled by `maxUnavailable: null` |
+| preflight.podDisruptionBudget.maxUnavailable | string | `"1"` | Maximum number/percentage of pods that may be made unavailable |
 | preflight.podLabels | object | `{}` | Labels to be added to the preflight pod. |
 | preflight.podSecurityContext | object | `{}` | Security context to be added to preflight pods. |
 | preflight.priorityClassName | string | `""` | The priority class to use for the preflight pod. |
@@ -682,18 +692,18 @@ contributors across the globe, there is almost always someone available to help.
 | preflight.updateStrategy | object | `{"type":"RollingUpdate"}` | preflight update strategy |
 | preflight.validateCNPs | bool | `true` | By default we should always validate the installed CNPs before upgrading Cilium. This will make sure the user will have the policies deployed in the cluster with the right schema. |
 | priorityClassName | string | `""` | The priority class to use for cilium-agent. |
-| prometheus | object | `{"enabled":false,"metrics":null,"port":9962,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":null,"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}],"trustCRDsExist":false}}` | Configure prometheus metrics on the configured port at /metrics |
-| prometheus.metrics | string | `nil` | Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/observability/metrics/ |
+| prometheus | object | `{"enabled":true,"metrics":["+cilium_bpf_map_pressure"],"port":9962,"serviceMonitor":{"annotations":{},"enabled":false,"interval":"10s","labels":{},"metricRelabelings":[],"relabelings":[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}],"trustCRDsExist":false}}` | Configure prometheus metrics on the configured port at /metrics |
+| prometheus.metrics | list | `["+cilium_bpf_map_pressure"]` | Metrics that should be enabled or disabled from the default metric list. The list is expected to be separated by a space. (+metric_foo to enable metric_foo , -metric_bar to disable metric_bar). ref: https://docs.cilium.io/en/stable/observability/metrics/ |
 | prometheus.serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.enabled | bool | `false` | Enable service monitors. This requires the prometheus CRDs to be available (see https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml) |
 | prometheus.serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
 | prometheus.serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor cilium-agent |
-| prometheus.serviceMonitor.metricRelabelings | string | `nil` | Metrics relabeling configs for the ServiceMonitor cilium-agent |
+| prometheus.serviceMonitor.metricRelabelings | list | `[]` | Metrics relabeling configs for the ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.relabelings | list | `[{"replacement":"${1}","sourceLabels":["__meta_kubernetes_pod_node_name"],"targetLabel":"node"}]` | Relabeling configs for the ServiceMonitor cilium-agent |
 | prometheus.serviceMonitor.trustCRDsExist | bool | `false` | Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying |
-| proxy | object | `{"prometheus":{"enabled":true,"port":null},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
+| proxy | object | `{"prometheus":{"enabled":true,"port":""},"sidecarImageRegex":"cilium/istio_proxy"}` | Configure Istio proxy options. |
 | proxy.prometheus.enabled | bool | `true` | Deprecated in favor of envoy.prometheus.enabled |
-| proxy.prometheus.port | string | `nil` | Deprecated in favor of envoy.prometheus.port |
+| proxy.prometheus.port | string | `""` | Deprecated in favor of envoy.prometheus.port |
 | proxy.sidecarImageRegex | string | `"cilium/istio_proxy"` | Regular expression matching compatible Istio sidecar istio-proxy container image names |
 | rbac.create | bool | `true` | Enable creation of Resource-Based Access Control configuration. |
 | readinessProbe.failureThreshold | int | `3` | failure threshold of readiness probe |

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -125,7 +125,7 @@ contributors across the globe, there is almost always someone available to help.
 | bpf.monitorInterval | string | `"5s"` | Configure the typical time between monitor notifications for active connections. |
 | bpf.natMax | int | `524288` | Configure the maximum number of entries for the NAT table. |
 | bpf.neighMax | int | `524288` | Configure the maximum number of entries for the neighbor table. |
-| bpf.policyMapMax | int | `16384` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
+| bpf.policyMapMax | int | `65536` | Configure the maximum number of entries in endpoint policy map (per endpoint). |
 | bpf.preallocateMaps | bool | `false` | Enables pre-allocation of eBPF map values. This increases memory usage but can reduce latency. |
 | bpf.root | string | `"/sys/fs/bpf"` | Configure the mount point for the BPF filesystem |
 | bpf.tproxy | bool | `false` | Configure the eBPF-based TPROXY to reduce reliance on iptables rules for implementing Layer 7 policy. |
@@ -221,7 +221,7 @@ contributors across the globe, there is almost always someone available to help.
 | clustermesh.config.enabled | bool | `false` | Enable the Clustermesh explicit configuration. |
 | clustermesh.useAPIServer | bool | `false` | Deploy clustermesh-apiserver for clustermesh |
 | cni.binPath | string | `"/opt/cni/bin"` | Configure the path to the CNI binary directory on the host. |
-| cni.chainingMode | string | `""` | Configure chaining on top of other CNI plugins. Possible values:  - none  - aws-cni  - flannel  - generic-veth  - portmap |
+| cni.chainingMode | string | `"none"` | Configure chaining on top of other CNI plugins. Possible values:  - none  - aws-cni  - flannel  - generic-veth  - portmap |
 | cni.chainingTarget | string | `""` | A CNI network name in to which the Cilium plugin should be added as a chained plugin. This will cause the agent to watch for a CNI network with this network name. When it is found, this will be used as the basis for Cilium's CNI configuration file. If this is set, it assumes a chaining mode of generic-veth. As a special case, a chaining mode of aws-cni implies a chainingTarget of aws-cni. |
 | cni.confFileMountPath | string | `"/tmp/cni-configuration"` | Configure the path to where to mount the ConfigMap inside the agent pod. |
 | cni.confPath | string | `"/etc/cni/net.d"` | Configure the path to the CNI configuration directory on the host. |

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -421,14 +421,14 @@ spec:
         command:
         - cilium
         - build-config
-        {{- if (not (kindIs "invalid" .Values.daemon.configSources)) }}
-        - "--source={{.Values.daemon.configSources}}"
+        {{- with .Values.daemon.configSources }}
+        - "--source={{.}}"
         {{- end }}
-        {{- if (not (kindIs "invalid" .Values.daemon.allowedConfigOverrides)) }}
-        - "--allow-config-keys={{.Values.daemon.allowedConfigOverrides}}"
+        {{- with .Values.daemon.allowedConfigOverrides }}
+        - "--allow-config-keys={{.}}"
         {{- end }}
-        {{- if (not (kindIs "invalid" .Values.daemon.blockedConfigOverrides)) }}
-        - "--deny-config-keys={{.Values.daemon.blockedConfigOverrides}}"
+        {{- with .Values.daemon.blockedConfigOverrides }}
+        - "--deny-config-keys={{.}}"
         {{- end }}
         env:
         - name: K8S_NODE_NAME

--- a/install/kubernetes/cilium/values.schema.json
+++ b/install/kubernetes/cilium/values.schema.json
@@ -190,7 +190,7 @@
                                                             "type": "string"
                                                         },
                                                         "storageClass": {
-                                                            "type": "null"
+                                                            "type": "string"
                                                         }
                                                     }
                                                 },
@@ -239,7 +239,7 @@
                                     }
                                 },
                                 "serverAddress": {
-                                    "type": "null"
+                                    "type": "string"
                                 },
                                 "trustDomain": {
                                     "type": "string"
@@ -309,7 +309,7 @@
             "type": "object",
             "properties": {
                 "authMapMax": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "autoMount": {
                     "type": "object",
@@ -320,13 +320,13 @@
                     }
                 },
                 "ctAnyMax": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "ctTcpMax": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "hostLegacyRouting": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "lbExternalClusterIP": {
                     "type": "boolean"
@@ -335,10 +335,10 @@
                     "type": "integer"
                 },
                 "mapDynamicSizeRatio": {
-                    "type": "null"
+                    "type": "number"
                 },
                 "masquerade": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "monitorAggregation": {
                     "type": "string"
@@ -350,10 +350,10 @@
                     "type": "string"
                 },
                 "natMax": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "neighMax": {
-                    "type": "null"
+                    "type": "integer"
                 },
                 "policyMapMax": {
                     "type": "integer"
@@ -365,10 +365,10 @@
                     "type": "string"
                 },
                 "tproxy": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "vlanBypass": {
-                    "type": "null"
+                    "type": "array"
                 }
             }
         },
@@ -399,7 +399,7 @@
                     "type": "object",
                     "properties": {
                         "override": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "pullPolicy": {
                             "type": "string"
@@ -509,7 +509,7 @@
                                     "type": "object",
                                     "properties": {
                                         "override": {
-                                            "type": "null"
+                                            "type": "string"
                                         },
                                         "pullPolicy": {
                                             "type": "string"
@@ -557,7 +557,7 @@
                                     "type": "string"
                                 },
                                 "override": {
-                                    "type": "null"
+                                    "type": "string"
                                 },
                                 "pullPolicy": {
                                     "type": "string"
@@ -595,7 +595,7 @@
                                             "type": "string"
                                         },
                                         "override": {
-                                            "type": "null"
+                                            "type": "string"
                                         },
                                         "pullPolicy": {
                                             "type": "string"
@@ -685,10 +685,10 @@
                                                     "type": "string"
                                                 },
                                                 "metricRelabelings": {
-                                                    "type": "null"
+                                                    "type": "array"
                                                 },
                                                 "relabelings": {
-                                                    "type": "null"
+                                                    "type": "array"
                                                 }
                                             }
                                         },
@@ -702,10 +702,10 @@
                                                     "type": "string"
                                                 },
                                                 "metricRelabelings": {
-                                                    "type": "null"
+                                                    "type": "array"
                                                 },
                                                 "relabelings": {
-                                                    "type": "null"
+                                                    "type": "array"
                                                 }
                                             }
                                         },
@@ -713,10 +713,10 @@
                                             "type": "object"
                                         },
                                         "metricRelabelings": {
-                                            "type": "null"
+                                            "type": "array"
                                         },
                                         "relabelings": {
-                                            "type": "null"
+                                            "type": "array"
                                         }
                                     }
                                 }
@@ -740,10 +740,7 @@
                                     "type": "boolean"
                                 },
                                 "maxUnavailable": {
-                                    "type": "integer"
-                                },
-                                "minAvailable": {
-                                    "type": "null"
+                                    "type": "string"
                                 }
                             }
                         },
@@ -772,10 +769,10 @@
                                     "type": "object"
                                 },
                                 "externalTrafficPolicy": {
-                                    "type": "null"
+                                    "type": "string"
                                 },
                                 "internalTrafficPolicy": {
-                                    "type": "null"
+                                    "type": "string"
                                 },
                                 "nodePort": {
                                     "type": "integer"
@@ -921,10 +918,10 @@
                     "type": "string"
                 },
                 "chainingMode": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "chainingTarget": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "confFileMountPath": {
                     "type": "string"
@@ -984,13 +981,13 @@
             "type": "object",
             "properties": {
                 "allowedConfigOverrides": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "blockedConfigOverrides": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "configSources": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "runPath": {
                     "type": "string"
@@ -1013,7 +1010,7 @@
                     "type": "string"
                 },
                 "namespace": {
-                    "type": "null"
+                    "type": "string"
                 }
             }
         },
@@ -1024,7 +1021,7 @@
                     "type": "boolean"
                 },
                 "verbose": {
-                    "type": "null"
+                    "type": "string"
                 }
             }
         },
@@ -1304,7 +1301,7 @@
                     "type": "integer"
                 },
                 "dnsPolicy": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "enabled": {
                     "type": "boolean"
@@ -1340,7 +1337,7 @@
                             "type": "string"
                         },
                         "override": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "pullPolicy": {
                             "type": "string"
@@ -1402,7 +1399,7 @@
                     "type": "object"
                 },
                 "priorityClassName": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "prometheus": {
                     "type": "object",
@@ -1429,7 +1426,7 @@
                                     "type": "object"
                                 },
                                 "metricRelabelings": {
-                                    "type": "null"
+                                    "type": "array"
                                 },
                                 "relabelings": {
                                     "type": "array",
@@ -1592,7 +1589,7 @@
                     "type": "object",
                     "properties": {
                         "override": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "pullPolicy": {
                             "type": "string"
@@ -1626,10 +1623,7 @@
                             "type": "boolean"
                         },
                         "maxUnavailable": {
-                            "type": "integer"
-                        },
-                        "minAvailable": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },
@@ -1874,7 +1868,7 @@
                                     "type": "string"
                                 },
                                 "namespace": {
-                                    "type": "null"
+                                    "type": "string"
                                 }
                             }
                         },
@@ -1882,7 +1876,7 @@
                             "type": "boolean"
                         },
                         "enabled": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "port": {
                             "type": "integer"
@@ -1906,7 +1900,7 @@
                                     "type": "object"
                                 },
                                 "metricRelabelings": {
-                                    "type": "null"
+                                    "type": "array"
                                 },
                                 "relabelings": {
                                     "type": "array",
@@ -1984,7 +1978,7 @@
                             }
                         },
                         "dialTimeout": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "enabled": {
                             "type": "boolean"
@@ -2016,7 +2010,7 @@
                                     "type": "string"
                                 },
                                 "override": {
-                                    "type": "null"
+                                    "type": "string"
                                 },
                                 "pullPolicy": {
                                     "type": "string"
@@ -2056,10 +2050,7 @@
                                     "type": "boolean"
                                 },
                                 "maxUnavailable": {
-                                    "type": "integer"
-                                },
-                                "minAvailable": {
-                                    "type": "null"
+                                    "type": "string"
                                 }
                             }
                         },
@@ -2116,10 +2107,10 @@
                                             "type": "object"
                                         },
                                         "metricRelabelings": {
-                                            "type": "null"
+                                            "type": "array"
                                         },
                                         "relabelings": {
-                                            "type": "null"
+                                            "type": "array"
                                         }
                                     }
                                 }
@@ -2132,7 +2123,7 @@
                             "type": "object"
                         },
                         "retryTimeout": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "rollOutPods": {
                             "type": "boolean"
@@ -2174,10 +2165,10 @@
                             }
                         },
                         "sortBufferDrainTimeout": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "sortBufferLenMax": {
-                            "type": "null"
+                            "type": "integer"
                         },
                         "terminationGracePeriodSeconds": {
                             "type": "integer"
@@ -2246,7 +2237,7 @@
                     }
                 },
                 "skipUnknownCGroupIDs": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "socketPath": {
                     "type": "string"
@@ -2321,7 +2312,7 @@
                                             "type": "string"
                                         },
                                         "override": {
-                                            "type": "null"
+                                            "type": "string"
                                         },
                                         "pullPolicy": {
                                             "type": "string"
@@ -2370,7 +2361,7 @@
                                             "type": "string"
                                         },
                                         "override": {
-                                            "type": "null"
+                                            "type": "string"
                                         },
                                         "pullPolicy": {
                                             "type": "string"
@@ -2451,10 +2442,7 @@
                                     "type": "boolean"
                                 },
                                 "maxUnavailable": {
-                                    "type": "integer"
-                                },
-                                "minAvailable": {
-                                    "type": "null"
+                                    "type": "string"
                                 }
                             }
                         },
@@ -2569,7 +2557,7 @@
                     "type": "string"
                 },
                 "override": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "pullPolicy": {
                     "type": "string"
@@ -2589,7 +2577,7 @@
             }
         },
         "imagePullSecrets": {
-            "type": "null"
+            "type": "array"
         },
         "ingressController": {
             "type": "object",
@@ -2598,10 +2586,10 @@
                     "type": "boolean"
                 },
                 "defaultSecretName": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "defaultSecretNamespace": {
-                    "type": "null"
+                    "type": "string"
                 },
                 "enabled": {
                     "type": "boolean"
@@ -2636,28 +2624,28 @@
                     "type": "object",
                     "properties": {
                         "allocateLoadBalancerNodePorts": {
-                            "type": "null"
+                            "type": "boolean"
                         },
                         "annotations": {
                             "type": "object"
                         },
                         "insecureNodePort": {
-                            "type": "null"
+                            "type": "integer"
                         },
                         "labels": {
                             "type": "object"
                         },
                         "loadBalancerClass": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "loadBalancerIP": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "name": {
                             "type": "string"
                         },
                         "secureNodePort": {
-                            "type": "null"
+                            "type": "integer"
                         },
                         "type": {
                             "type": "string"
@@ -2714,10 +2702,10 @@
                             }
                         },
                         "externalAPILimitBurstSize": {
-                            "type": "null"
+                            "type": "integer"
                         },
                         "externalAPILimitQPS": {
-                            "type": "null"
+                            "type": "number"
                         }
                     }
                 }
@@ -2929,7 +2917,7 @@
                     "type": "object",
                     "properties": {
                         "override": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "pullPolicy": {
                             "type": "string"
@@ -3101,7 +3089,7 @@
                             "type": "string"
                         },
                         "namespace": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },
@@ -3151,7 +3139,7 @@
                             "type": "string"
                         },
                         "override": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "pullPolicy": {
                             "type": "string"
@@ -3191,10 +3179,7 @@
                             "type": "boolean"
                         },
                         "maxUnavailable": {
-                            "type": "integer"
-                        },
-                        "minAvailable": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },
@@ -3246,10 +3231,10 @@
                                     "type": "object"
                                 },
                                 "metricRelabelings": {
-                                    "type": "null"
+                                    "type": "array"
                                 },
                                 "relabelings": {
-                                    "type": "null"
+                                    "type": "array"
                                 }
                             }
                         }
@@ -3274,7 +3259,7 @@
                     "type": "boolean"
                 },
                 "setNodeTaints": {
-                    "type": "null"
+                    "type": "boolean"
                 },
                 "skipCNPStatusStartupClean": {
                     "type": "boolean"
@@ -3418,7 +3403,7 @@
                             "type": "string"
                         },
                         "override": {
-                            "type": "null"
+                            "type": "string"
                         },
                         "pullPolicy": {
                             "type": "string"
@@ -3452,10 +3437,7 @@
                             "type": "boolean"
                         },
                         "maxUnavailable": {
-                            "type": "integer"
-                        },
-                        "minAvailable": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },
@@ -3541,7 +3523,7 @@
                             "type": "object"
                         },
                         "metricRelabelings": {
-                            "type": "null"
+                            "type": "array"
                         },
                         "relabelings": {
                             "type": "array",
@@ -3580,7 +3562,7 @@
                             "type": "boolean"
                         },
                         "port": {
-                            "type": "null"
+                            "type": "string"
                         }
                     }
                 },

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -22,14 +22,14 @@ debug:
   # - envoy
   # - datapath
   # - policy
-  verbose: ~
+  verbose: ""
 
 rbac:
   # -- Enable creation of Resource-Based Access Control configuration.
   create: true
 
 # -- Configure image pull secrets for pulling container images
-imagePullSecrets:
+imagePullSecrets: []
 # - name: "image-pull-secret"
 
 # -- (string) Kubernetes config path
@@ -151,7 +151,7 @@ rollOutCiliumPods: false
 # -- Agent container image.
 image:
   registry: gsoci.azurecr.io
-  override: ~
+  override: ""
   repository: "giantswarm/cilium"
   tag: "v1.14.5"
   pullPolicy: "IfNotPresent"
@@ -442,17 +442,17 @@ bpf:
 
   # -- (int) Configure the maximum number of entries in auth map.
   # @default -- `524288`
-  authMapMax: ~
+  authMapMax: 524288
 
   # -- (int) Configure the maximum number of entries in the TCP connection tracking
   # table.
   # @default -- `524288`
-  ctTcpMax: ~
+  ctTcpMax: 524288
 
   # -- (int) Configure the maximum number of entries for the non-TCP connection
   # tracking table.
   # @default -- `262144`
-  ctAnyMax: ~
+  ctAnyMax: 262144
 
   # -- Configure the maximum number of service entries in the
   # load balancer maps.
@@ -460,19 +460,19 @@ bpf:
 
   # -- (int) Configure the maximum number of entries for the NAT table.
   # @default -- `524288`
-  natMax: ~
+  natMax: 524288
 
   # -- (int) Configure the maximum number of entries for the neighbor table.
   # @default -- `524288`
-  neighMax: ~
+  neighMax: 524288
 
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
-  policyMapMax: 65536
+  policyMapMax: 16384
 
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
   # @default -- `0.0025`
-  mapDynamicSizeRatio: ~
+  mapDynamicSizeRatio: 0.0025
 
   # -- Configure the level of aggregation for monitor notifications.
   # Valid options are none, low, medium, maximum.
@@ -491,24 +491,24 @@ bpf:
 
   # -- (bool) Enable native IP masquerade support in eBPF
   # @default -- `false`
-  masquerade: ~
+  masquerade: false
 
   # -- (bool) Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if
   # the kernel supports it. The latter has the implication that it will also
   # bypass netfilter in the host namespace.
   # @default -- `false`
-  hostLegacyRouting: ~
+  hostLegacyRouting: false
 
   # -- (bool) Configure the eBPF-based TPROXY to reduce reliance on iptables rules
   # for implementing Layer 7 policy.
   # @default -- `false`
-  tproxy: ~
+  tproxy: false
 
   # -- (list) Configure explicitly allowed VLAN id's for bpf logic bypass.
   # [0] will allow all VLAN id's without any filtering.
   # @default -- `[]`
-  vlanBypass: ~
+  vlanBypass: []
 
 # -- Enable BPF clock source probing for more efficient tick retrieval.
 bpfClockProbe: false
@@ -547,14 +547,14 @@ cni:
   #  - flannel
   #  - generic-veth
   #  - portmap
-  chainingMode: ~
+  chainingMode: ""
 
   # -- A CNI network name in to which the Cilium plugin should be added as a chained plugin.
   # This will cause the agent to watch for a CNI network with this network name. When it is
   # found, this will be used as the basis for Cilium's CNI configuration file. If this is
   # set, it assumes a chaining mode of generic-veth. As a special case, a chaining mode
   # of aws-cni implies a chainingTarget of aws-cni.
-  chainingTarget: ~
+  chainingTarget: ""
 
   # -- Make Cilium take ownership over the `/etc/cni/net.d` directory on the
   # node, renaming all non-Cilium CNI configurations to `*.cilium_bak`.
@@ -636,7 +636,7 @@ daemon:
   # The default is "config-map:cilium-config,cilium-node-config". For supported
   # values, see the help text for the build-config subcommand.
   # Note that this value should be a comma-separated string.
-  configSources: ~
+  configSources: ""
 
   # -- allowedConfigOverrides is a list of config-map keys that can be overridden.
   # That is to say, if this value is set, config sources (excepting the first one) can
@@ -646,7 +646,7 @@ daemon:
   #
   # By default, all keys may be overridden. To disable overrides, set this to "none" or
   # change the configSources variable.
-  allowedConfigOverrides: ~
+  allowedConfigOverrides: ""
 
   # -- blockedConfigOverrides is a list of config-map keys that may not be overridden.
   # In other words, if any of these keys appear in a configuration source excepting the
@@ -655,7 +655,7 @@ daemon:
   # This is ignored if allowedConfigOverrides is set.
   #
   # By default, all keys may be overridden.
-  blockedConfigOverrides: ~
+  blockedConfigOverrides: ""
 
 # -- Specify which network interfaces can run the eBPF datapath. This means
 # that a packet sent from a pod to a destination outside the cluster will be
@@ -728,10 +728,10 @@ ingressController:
   ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
 
   # -- Default secret namespace for ingresses without .spec.tls[].secretName set.
-  defaultSecretNamespace:
+  defaultSecretNamespace: ""
 
   # -- Default secret name for ingresses without .spec.tls[].secretName set.
-  defaultSecretName:
+  defaultSecretName: ""
 
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
@@ -757,16 +757,16 @@ ingressController:
     # -- Service type for the shared LB service
     type: LoadBalancer
     # -- Configure a specific nodePort for insecure HTTP traffic on the shared LB service
-    insecureNodePort: ~
+    insecureNodePort: 0
     # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
-    secureNodePort : ~
+    secureNodePort : 0
     # -- Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
-    loadBalancerClass: ~
+    loadBalancerClass: ""
     # -- Configure a specific loadBalancerIP on the shared LB service
-    loadBalancerIP : ~
+    loadBalancerIP : ""
     # -- Configure if node port allocation is required for LB service
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
-    allocateLoadBalancerNodePorts: ~
+    allocateLoadBalancerNodePorts: true
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium
@@ -945,7 +945,7 @@ socketLB:
 # (re)generate any certificates not provided manually.
 certgen:
   image:
-    override: ~
+    override: ""
     repository: "giantswarm/cilium-certgen"
     tag: "v0.1.9@sha256:89a0847753686444daabde9474b48340993bd19c7bea66a46e45b2974b82041f"
     pullPolicy: "IfNotPresent"
@@ -1001,7 +1001,7 @@ hubble:
     #
     #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
     #
-    enabled: ~
+    enabled: ""
     # -- Enables exporting hubble metrics in OpenMetrics format.
     enableOpenMetrics: false
     # -- Configure the port the hubble metric server listens on.
@@ -1026,14 +1026,14 @@ hubble:
           targetLabel: node
           replacement: ${1}
       # -- Metrics relabeling configs for the ServiceMonitor hubble
-      metricRelabelings: ~
+      metricRelabelings: []
     # -- Grafana dashboards for hubble
     # grafana can import dashboards based on the label and value
     # ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards
     dashboards:
       enabled: false
       label: grafana_dashboard
-      namespace: ~
+      namespace: ""
       labelValue: "1"
       annotations: {}
 
@@ -1048,7 +1048,7 @@ hubble:
   preferIpv6: false
   # -- (bool) Skip Hubble events with unknown cgroup ids
   # @default -- `true`
-  skipUnknownCGroupIDs: ~
+  skipUnknownCGroupIDs: true
 
   peerService:
     # -- Service Port for the Peer service.
@@ -1119,7 +1119,7 @@ hubble:
 
     # -- Hubble-relay container image.
     image:
-      override: ~
+      override: ""
       repository: "giantswarm/hubble-relay"
       tag: "v1.14.5"
        # hubble-relay-digest
@@ -1173,9 +1173,9 @@ hubble:
       enabled: false
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-      minAvailable: null
+      # minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
-      maxUnavailable: 1
+      maxUnavailable: "1"
 
     # -- The priority class to use for hubble-relay
     priorityClassName: ""
@@ -1249,18 +1249,18 @@ hubble:
         extraIpAddresses: []
 
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
-    dialTimeout: ~
+    dialTimeout: ""
 
     # -- Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
-    retryTimeout: ~
+    retryTimeout: ""
 
     # -- Max number of flows that can be buffered for sorting before being sent to the
     # client (per request) (e.g. 100).
-    sortBufferLenMax: ~
+    sortBufferLenMax: 100
 
     # -- When the per-request flows sort buffer is not full, a flow is drained every
     # time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
-    sortBufferDrainTimeout: ~
+    sortBufferDrainTimeout: ""
 
     # -- Port to use for the k8s service backed by hubble-relay pods.
     # If not set, it is dynamically assigned to port 443 if TLS is enabled and to
@@ -1286,9 +1286,9 @@ hubble:
         # service monitors configured.
         # namespace: ""
         # -- Relabeling configs for the ServiceMonitor hubble-relay
-        relabelings: ~
+        relabelings: []
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
-        metricRelabelings: ~
+        metricRelabelings: []
 
     gops:
       # -- Enable gops for hubble-relay
@@ -1347,7 +1347,7 @@ hubble:
     backend:
       # -- Hubble-ui backend image.
       image:
-        override: ~
+        override: ""
         repository: "giantswarm/hubble-ui-backend"
         tag: "v0.12.1"
         digest: "sha256:1f86f3400827a0451e6332262467f894eeb7caf0eb8779bd951e2caa9d027cbe"
@@ -1378,7 +1378,7 @@ hubble:
     frontend:
       # -- Hubble-ui frontend image.
       image:
-        override: ~
+        override: ""
         repository: "giantswarm/hubble-ui"
         tag: "v0.12.1"
         digest: "sha256:9e5f81ee747866480ea1ac4630eb6975ff9227f9782b7c93919c081c33f38267"
@@ -1426,9 +1426,9 @@ hubble:
       enabled: false
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-      minAvailable: null
+      # minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
-      maxUnavailable: 1
+      maxUnavailable: "1"
 
     # -- Affinity for hubble-ui
     affinity: {}
@@ -1535,12 +1535,12 @@ ipam:
     # -- The maximum burst size when rate limiting access to external APIs.
     # Also known as the token bucket capacity.
     # @default -- `20`
-    externalAPILimitBurstSize: ~
+    externalAPILimitBurstSize: 20
     # -- The maximum queries per second when rate limiting access to
     # external APIs. Also known as the bucket refill rate, which is used to
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
-    externalAPILimitQPS: ~
+    externalAPILimitQPS: 4.0
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:
@@ -1808,7 +1808,7 @@ prometheus:
         targetLabel: node
         replacement: ${1}
     # -- Metrics relabeling configs for the ServiceMonitor cilium-agent
-    metricRelabelings: ~
+    metricRelabelings: []
     # -- Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying
     trustCRDsExist: false
 
@@ -1825,7 +1825,7 @@ prometheus:
 dashboards:
   enabled: false
   label: grafana_dashboard
-  namespace: ~
+  namespace: ""
   labelValue: "1"
   annotations: {}
 
@@ -1836,7 +1836,7 @@ proxy:
     # -- Deprecated in favor of envoy.prometheus.enabled
     enabled: true
     # -- Deprecated in favor of envoy.prometheus.port
-    port: ~
+    port: ""
   # -- Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
   sidecarImageRegex: "cilium/istio_proxy"
@@ -1864,7 +1864,7 @@ envoy:
 
   # -- Envoy container image.
   image:
-    override: ~
+    override: ""
     repository: "quay.io/cilium/cilium-envoy"
     tag: "v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b"
     pullPolicy: "IfNotPresent"
@@ -1996,11 +1996,11 @@ envoy:
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
   # -- The priority class to use for cilium-envoy.
-  priorityClassName: ~
+  priorityClassName: ""
 
   # -- DNS policy for Cilium envoy pods.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-  dnsPolicy: ~
+  dnsPolicy: ""
 
   prometheus:
     # -- Enable prometheus metrics for cilium-envoy
@@ -2025,7 +2025,7 @@ envoy:
           targetLabel: node
           replacement: ${1}
       # -- Metrics relabeling configs for the ServiceMonitor cilium-envoy
-      metricRelabelings: ~
+      metricRelabelings: []
     # -- Serve prometheus metrics for cilium-envoy on the configured port
     port: "9964"
 
@@ -2156,7 +2156,7 @@ etcd:
 
   # -- cilium-etcd-operator image.
   image:
-    override: ~
+    override: ""
     repository: "giantswarm/cilium-etcd-operator"
     tag: "v2.0.7@sha256:04b8327f7f992693c2cb483b999041ed8f92efc8e14f2a5f3ab95574a65ea2dc"
     pullPolicy: "IfNotPresent"
@@ -2209,9 +2209,9 @@ etcd:
     enabled: false
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-    minAvailable: null
+    # minAvailable: null
     # -- Maximum number/percentage of pods that may be made unavailable
-    maxUnavailable: 1
+    maxUnavailable: "1"
 
   # -- cilium-etcd-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2259,7 +2259,7 @@ operator:
 
   # -- cilium-operator image.
   image:
-    override: ~
+    override: ""
     repository: "giantswarm/cilium-operator"
     tag: "v1.14.5"
     # operator-generic-digest
@@ -2357,9 +2357,9 @@ operator:
     enabled: true
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-    minAvailable: null
+    # minAvailable: null
     # -- Maximum number/percentage of pods that may be made unavailable
-    maxUnavailable: 1
+    maxUnavailable: "1"
 
   # -- cilium-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2414,9 +2414,9 @@ operator:
       # -- Interval for scrape metrics.
       interval: "10s"
       # -- Relabeling configs for the ServiceMonitor cilium-operator
-      relabelings: ~
+      relabelings: []
       # -- Metrics relabeling configs for the ServiceMonitor cilium-operator
-      metricRelabelings: ~
+      metricRelabelings: []
 
   # -- Grafana dashboards for cilium-operator
   # grafana can import dashboards based on the label and value
@@ -2424,7 +2424,7 @@ operator:
   dashboards:
     enabled: false
     label: grafana_dashboard
-    namespace: ~
+    namespace: ""
     labelValue: "1"
     annotations: {}
 
@@ -2438,7 +2438,7 @@ operator:
   # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
   # from being scheduled to nodes where Cilium is not the default CNI provider.
   # @default -- same as removeNodeTaints
-  setNodeTaints: ~
+  setNodeTaints: false
 
   # -- Set Node condition NetworkUnavailable to 'false' with the reason
   # 'CiliumIsUp' for nodes that have a healthy Cilium pod.
@@ -2457,7 +2457,7 @@ nodeinit:
 
   # -- node-init image.
   image:
-    override: ~
+    override: ""
     repository: "giantswarm/cilium-startup-script"
     tag: "62093c5c233ea914bfa26a10ba41f8780d9b737f"
     pullPolicy: "IfNotPresent"
@@ -2546,7 +2546,7 @@ preflight:
 
   # -- Cilium pre-flight image.
   image:
-    override: ~
+    override: ""
     repository: "giantswarm/cilium"
     tag: "v1.14.5"
     # cilium-digest
@@ -2619,9 +2619,9 @@ preflight:
     enabled: false
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-    minAvailable: null
+    # minAvailable: null
     # -- Maximum number/percentage of pods that may be made unavailable
-    maxUnavailable: 1
+    maxUnavailable: "1"
 
   # -- preflight resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2696,7 +2696,7 @@ clustermesh:
   apiserver:
     # -- Clustermesh API server image.
     image:
-      override: ~
+      override: ""
       repository: "giantswarm/cilium-clustermesh-apiserver"
       tag: "v1.14.5"
       # clustermesh-apiserver-digest
@@ -2707,7 +2707,7 @@ clustermesh:
     etcd:
       # -- Clustermesh API server etcd image.
       image:
-        override: ~
+        override: ""
         repository: "giantswarm/etcd"
         tag: "v3.5.4@sha256:795d8660c48c439a7c3764c2330ed9222ab5db5bb524d8d0607cac76f7ba82a3"
         pullPolicy: "IfNotPresent"
@@ -2741,7 +2741,7 @@ clustermesh:
 
       # -- KVStoreMesh image.
       image:
-        override: ~
+        override: ""
         repository: "quay.io/cilium/kvstoremesh"
         tag: "v1.14.5"
         # kvstoremesh-digest
@@ -2796,10 +2796,10 @@ clustermesh:
       annotations: {}
 
       # -- The externalTrafficPolicy of service used for apiserver access.
-      externalTrafficPolicy:
+      externalTrafficPolicy: Cluster
 
       # -- The internalTrafficPolicy of service used for apiserver access.
-      internalTrafficPolicy:
+      internalTrafficPolicy: Cluster
 
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
@@ -2835,9 +2835,9 @@ clustermesh:
       enabled: false
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-      minAvailable: null
+      # minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
-      maxUnavailable: 1
+      maxUnavailable: "1"
 
     # -- Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as
     #     resources:
@@ -3018,25 +3018,25 @@ clustermesh:
         # -- Interval for scrape metrics (apiserver metrics)
         interval: "10s"
         # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
-        relabelings: ~
+        relabelings: []
         # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
-        metricRelabelings: ~
+        metricRelabelings: []
 
         kvstoremesh:
           # -- Interval for scrape metrics (KVStoreMesh metrics)
           interval: "10s"
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
-          relabelings: ~
+          relabelings: []
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
-          metricRelabelings: ~
+          metricRelabelings: []
 
         etcd:
           # -- Interval for scrape metrics (etcd metrics)
           interval: "10s"
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
-          relabelings: ~
+          relabelings: []
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
-          metricRelabelings: ~
+          metricRelabelings: []
 
 # -- Configure external workloads support
 externalWorkloads:
@@ -3200,7 +3200,7 @@ authentication:
             # -- Access mode of the SPIRE server data storage
             accessMode: ReadWriteOnce
             # -- StorageClass of the SPIRE server data storage
-            storageClass: null
+            storageClass: ""
           # SPIRE CA configuration
           ca:
             # -- SPIRE CA key type
@@ -3217,7 +3217,7 @@ authentication:
       # Cilium Operator will resolve its address by looking up the clusterIP from Service resource.
       #
       # Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081
-      serverAddress: ~
+      serverAddress: ""
       # -- SPIFFE trust domain to use for fetching certificates
       trustDomain: spiffe.cilium
       # -- SPIRE socket path where the SPIRE delegated api agent is listening

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -467,7 +467,7 @@ bpf:
   neighMax: 524288
 
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
-  policyMapMax: 16384
+  policyMapMax: 65536
 
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
@@ -547,7 +547,7 @@ cni:
   #  - flannel
   #  - generic-veth
   #  - portmap
-  chainingMode: ""
+  chainingMode: "none"
 
   # -- A CNI network name in to which the Cilium plugin should be added as a chained plugin.
   # This will cause the agent to watch for a CNI network with this network name. When it is
@@ -2438,7 +2438,7 @@ operator:
   # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
   # from being scheduled to nodes where Cilium is not the default CNI provider.
   # @default -- same as removeNodeTaints
-  setNodeTaints: false
+  setNodeTaints: true
 
   # -- Set Node condition NetworkUnavailable to 'false' with the reason
   # 'CiliumIsUp' for nodes that have a healthy Cilium pod.

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -19,14 +19,14 @@ debug:
   # - envoy
   # - datapath
   # - policy
-  verbose: ~
+  verbose: ""
 
 rbac:
   # -- Enable creation of Resource-Based Access Control configuration.
   create: true
 
 # -- Configure image pull secrets for pulling container images
-imagePullSecrets:
+imagePullSecrets: []
 # - name: "image-pull-secret"
 
 # -- (string) Kubernetes config path
@@ -123,6 +123,15 @@ serviceAccounts:
     name: hubble-generate-certs
     automount: true
     annotations: {}
+  defaultPolicies:
+    create: true
+    name: cilium-default-policies
+    automount: true
+    annotations: {}
+  extraPolicies:
+    create: true
+    name: cilium-extra-policies
+    annotations: {}
 
 # -- Configure termination grace period for cilium-agent DaemonSet.
 terminationGracePeriodSeconds: 1
@@ -138,7 +147,8 @@ rollOutCiliumPods: false
 
 # -- Agent container image.
 image:
-  override: ~
+  registry: gsoci.azurecr.io
+  override: ""
   repository: "${CILIUM_REPO}"
   tag: "${CILIUM_VERSION}"
   pullPolicy: "${PULL_POLICY}"
@@ -429,17 +439,17 @@ bpf:
 
   # -- (int) Configure the maximum number of entries in auth map.
   # @default -- `524288`
-  authMapMax: ~
+  authMapMax: 524288
 
   # -- (int) Configure the maximum number of entries in the TCP connection tracking
   # table.
   # @default -- `524288`
-  ctTcpMax: ~
+  ctTcpMax: 524288
 
   # -- (int) Configure the maximum number of entries for the non-TCP connection
   # tracking table.
   # @default -- `262144`
-  ctAnyMax: ~
+  ctAnyMax: 262144
 
   # -- Configure the maximum number of service entries in the
   # load balancer maps.
@@ -447,11 +457,11 @@ bpf:
 
   # -- (int) Configure the maximum number of entries for the NAT table.
   # @default -- `524288`
-  natMax: ~
+  natMax: 524288
 
   # -- (int) Configure the maximum number of entries for the neighbor table.
   # @default -- `524288`
-  neighMax: ~
+  neighMax: 524288
 
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
   policyMapMax: 16384
@@ -459,7 +469,7 @@ bpf:
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
   # @default -- `0.0025`
-  mapDynamicSizeRatio: ~
+  mapDynamicSizeRatio: 0.0025
 
   # -- Configure the level of aggregation for monitor notifications.
   # Valid options are none, low, medium, maximum.
@@ -478,24 +488,24 @@ bpf:
 
   # -- (bool) Enable native IP masquerade support in eBPF
   # @default -- `false`
-  masquerade: ~
+  masquerade: false
 
   # -- (bool) Configure whether direct routing mode should route traffic via
   # host stack (true) or directly and more efficiently out of BPF (false) if
   # the kernel supports it. The latter has the implication that it will also
   # bypass netfilter in the host namespace.
   # @default -- `false`
-  hostLegacyRouting: ~
+  hostLegacyRouting: false
 
   # -- (bool) Configure the eBPF-based TPROXY to reduce reliance on iptables rules
   # for implementing Layer 7 policy.
   # @default -- `false`
-  tproxy: ~
+  tproxy: false
 
   # -- (list) Configure explicitly allowed VLAN id's for bpf logic bypass.
   # [0] will allow all VLAN id's without any filtering.
   # @default -- `[]`
-  vlanBypass: ~
+  vlanBypass: []
 
 # -- Enable BPF clock source probing for more efficient tick retrieval.
 bpfClockProbe: false
@@ -534,14 +544,14 @@ cni:
   #  - flannel
   #  - generic-veth
   #  - portmap
-  chainingMode: ~
+  chainingMode: ""
 
   # -- A CNI network name in to which the Cilium plugin should be added as a chained plugin.
   # This will cause the agent to watch for a CNI network with this network name. When it is
   # found, this will be used as the basis for Cilium's CNI configuration file. If this is
   # set, it assumes a chaining mode of generic-veth. As a special case, a chaining mode
   # of aws-cni implies a chainingTarget of aws-cni.
-  chainingTarget: ~
+  chainingTarget: ""
 
   # -- Make Cilium take ownership over the `/etc/cni/net.d` directory on the
   # node, renaming all non-Cilium CNI configurations to `*.cilium_bak`.
@@ -623,7 +633,7 @@ daemon:
   # The default is "config-map:cilium-config,cilium-node-config". For supported
   # values, see the help text for the build-config subcommand.
   # Note that this value should be a comma-separated string.
-  configSources: ~
+  configSources: ""
 
   # -- allowedConfigOverrides is a list of config-map keys that can be overridden.
   # That is to say, if this value is set, config sources (excepting the first one) can
@@ -633,7 +643,7 @@ daemon:
   #
   # By default, all keys may be overridden. To disable overrides, set this to "none" or
   # change the configSources variable.
-  allowedConfigOverrides: ~
+  allowedConfigOverrides: ""
 
   # -- blockedConfigOverrides is a list of config-map keys that may not be overridden.
   # In other words, if any of these keys appear in a configuration source excepting the
@@ -642,7 +652,7 @@ daemon:
   # This is ignored if allowedConfigOverrides is set.
   #
   # By default, all keys may be overridden.
-  blockedConfigOverrides: ~
+  blockedConfigOverrides: ""
 
 # -- Specify which network interfaces can run the eBPF datapath. This means
 # that a packet sent from a pod to a destination outside the cluster will be
@@ -715,10 +725,10 @@ ingressController:
   ingressLBAnnotationPrefixes: ['service.beta.kubernetes.io', 'service.kubernetes.io', 'cloud.google.com']
 
   # -- Default secret namespace for ingresses without .spec.tls[].secretName set.
-  defaultSecretNamespace:
+  defaultSecretNamespace: ""
 
   # -- Default secret name for ingresses without .spec.tls[].secretName set.
-  defaultSecretName:
+  defaultSecretName: ""
 
   # -- SecretsNamespace is the namespace in which envoy SDS will retrieve TLS secrets from.
   secretsNamespace:
@@ -744,16 +754,16 @@ ingressController:
     # -- Service type for the shared LB service
     type: LoadBalancer
     # -- Configure a specific nodePort for insecure HTTP traffic on the shared LB service
-    insecureNodePort: ~
+    insecureNodePort: 0
     # -- Configure a specific nodePort for secure HTTPS traffic on the shared LB service
-    secureNodePort : ~
+    secureNodePort : 0
     # -- Configure a specific loadBalancerClass on the shared LB service (requires Kubernetes 1.24+)
-    loadBalancerClass: ~
+    loadBalancerClass: ""
     # -- Configure a specific loadBalancerIP on the shared LB service
-    loadBalancerIP : ~
+    loadBalancerIP : ""
     # -- Configure if node port allocation is required for LB service
     # ref: https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-nodeport-allocation
-    allocateLoadBalancerNodePorts: ~
+    allocateLoadBalancerNodePorts: true
 
 gatewayAPI:
   # -- Enable support for Gateway API in cilium
@@ -932,11 +942,9 @@ socketLB:
 # (re)generate any certificates not provided manually.
 certgen:
   image:
-    override: ~
+    override: ""
     repository: "${CERTGEN_REPO}"
     tag: "${CERTGEN_VERSION}"
-    digest: "${CERTGEN_DIGEST}"
-    useDigest: true
     pullPolicy: "${PULL_POLICY}"
   # -- Seconds after which the completed job pod will be deleted
   ttlSecondsAfterFinished: 1800
@@ -990,7 +998,7 @@ hubble:
     #
     #   --set metrics.enabled="{dns:query;ignoreAAAA,drop,tcp,flow,icmp,http}"
     #
-    enabled: ~
+    enabled: ""
     # -- Enables exporting hubble metrics in OpenMetrics format.
     enableOpenMetrics: false
     # -- Configure the port the hubble metric server listens on.
@@ -1015,14 +1023,14 @@ hubble:
           targetLabel: node
           replacement: ${1}
       # -- Metrics relabeling configs for the ServiceMonitor hubble
-      metricRelabelings: ~
+      metricRelabelings: []
     # -- Grafana dashboards for hubble
     # grafana can import dashboards based on the label and value
     # ref: https://github.com/grafana/helm-charts/tree/main/charts/grafana#sidecar-for-dashboards
     dashboards:
       enabled: false
       label: grafana_dashboard
-      namespace: ~
+      namespace: ""
       labelValue: "1"
       annotations: {}
 
@@ -1037,7 +1045,7 @@ hubble:
   preferIpv6: false
   # -- (bool) Skip Hubble events with unknown cgroup ids
   # @default -- `true`
-  skipUnknownCGroupIDs: ~
+  skipUnknownCGroupIDs: true
 
   peerService:
     # -- Service Port for the Peer service.
@@ -1101,14 +1109,14 @@ hubble:
 
   relay:
     # -- Enable Hubble Relay (requires hubble.enabled=true)
-    enabled: false
+    enabled: true
 
     # -- Roll out Hubble Relay pods automatically when configmap is updated.
     rollOutPods: false
 
     # -- Hubble-relay container image.
     image:
-      override: ~
+      override: ""
       repository: "${HUBBLE_RELAY_REPO}"
       tag: "${CILIUM_VERSION}"
        # hubble-relay-digest
@@ -1162,9 +1170,9 @@ hubble:
       enabled: false
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-      minAvailable: null
+      # minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
-      maxUnavailable: 1
+      maxUnavailable: "1"
 
     # -- The priority class to use for hubble-relay
     priorityClassName: ""
@@ -1238,18 +1246,18 @@ hubble:
         extraIpAddresses: []
 
     # -- Dial timeout to connect to the local hubble instance to receive peer information (e.g. "30s").
-    dialTimeout: ~
+    dialTimeout: ""
 
     # -- Backoff duration to retry connecting to the local hubble instance in case of failure (e.g. "30s").
-    retryTimeout: ~
+    retryTimeout: ""
 
     # -- Max number of flows that can be buffered for sorting before being sent to the
     # client (per request) (e.g. 100).
-    sortBufferLenMax: ~
+    sortBufferLenMax: 100
 
     # -- When the per-request flows sort buffer is not full, a flow is drained every
     # time this timeout is reached (only affects requests in follow-mode) (e.g. "1s").
-    sortBufferDrainTimeout: ~
+    sortBufferDrainTimeout: ""
 
     # -- Port to use for the k8s service backed by hubble-relay pods.
     # If not set, it is dynamically assigned to port 443 if TLS is enabled and to
@@ -1259,7 +1267,7 @@ hubble:
     # -- Enable prometheus metrics for hubble-relay on the configured port at
     # /metrics
     prometheus:
-      enabled: false
+      enabled: true
       port: 9966
       serviceMonitor:
         # -- Enable service monitors.
@@ -1275,9 +1283,9 @@ hubble:
         # service monitors configured.
         # namespace: ""
         # -- Relabeling configs for the ServiceMonitor hubble-relay
-        relabelings: ~
+        relabelings: []
         # -- Metrics relabeling configs for the ServiceMonitor hubble-relay
-        metricRelabelings: ~
+        metricRelabelings: []
 
     gops:
       # -- Enable gops for hubble-relay
@@ -1295,7 +1303,7 @@ hubble:
 
   ui:
     # -- Whether to enable the Hubble UI.
-    enabled: false
+    enabled: true
 
     standalone:
       # -- When true, it will allow installing the Hubble UI only, without checking dependencies.
@@ -1336,11 +1344,11 @@ hubble:
     backend:
       # -- Hubble-ui backend image.
       image:
-        override: ~
+        override: ""
         repository: "${HUBBLE_UI_BACKEND_REPO}"
         tag: "${HUBBLE_UI_BACKEND_VERSION}"
         digest: "${HUBBLE_UI_BACKEND_DIGEST}"
-        useDigest: true
+        useDigest: false
         pullPolicy: "${PULL_POLICY}"
 
       # -- Hubble-ui backend security context.
@@ -1367,11 +1375,11 @@ hubble:
     frontend:
       # -- Hubble-ui frontend image.
       image:
-        override: ~
+        override: ""
         repository: "${HUBBLE_UI_FRONTEND_REPO}"
         tag: "${HUBBLE_UI_FRONTEND_VERSION}"
         digest: "${HUBBLE_UI_FRONTEND_DIGEST}"
-        useDigest: true
+        useDigest: false
         pullPolicy: "${PULL_POLICY}"
 
       # -- Hubble-ui frontend security context.
@@ -1415,9 +1423,9 @@ hubble:
       enabled: false
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-      minAvailable: null
+      # minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
-      maxUnavailable: 1
+      maxUnavailable: "1"
 
     # -- Affinity for hubble-ui
     affinity: {}
@@ -1524,12 +1532,12 @@ ipam:
     # -- The maximum burst size when rate limiting access to external APIs.
     # Also known as the token bucket capacity.
     # @default -- `20`
-    externalAPILimitBurstSize: ~
+    externalAPILimitBurstSize: 20
     # -- The maximum queries per second when rate limiting access to
     # external APIs. Also known as the bucket refill rate, which is used to
     # refill the bucket up to the burst size capacity.
     # @default -- `4.0`
-    externalAPILimitQPS: ~
+    externalAPILimitQPS: 4.0
 
 # -- Configure the eBPF-based ip-masq-agent
 ipMasqAgent:
@@ -1605,10 +1613,10 @@ l2NeighDiscovery:
 l7Proxy: true
 
 # -- Enable Local Redirect Policy.
-localRedirectPolicy: false
+localRedirectPolicy: true
 
 # To include or exclude matched resources from cilium identity evaluation
-# labels: ""
+labels: "k8s:!.*/enforce k8s:!.*fluxcd.io/.* k8s:!.*kubernetes.io/managed-by.* k8s:!controller-uid k8s:!job-name"
 
 # logOptions allows you to define logging options. eg:
 # logOptions:
@@ -1775,7 +1783,7 @@ pprof:
 
 # -- Configure prometheus metrics on the configured port at /metrics
 prometheus:
-  enabled: false
+  enabled: true
   port: 9962
   serviceMonitor:
     # -- Enable service monitors.
@@ -1797,7 +1805,7 @@ prometheus:
         targetLabel: node
         replacement: ${1}
     # -- Metrics relabeling configs for the ServiceMonitor cilium-agent
-    metricRelabelings: ~
+    metricRelabelings: []
     # -- Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying
     trustCRDsExist: false
 
@@ -1805,7 +1813,8 @@ prometheus:
   # The list is expected to be separated by a space. (+metric_foo to enable
   # metric_foo , -metric_bar to disable metric_bar).
   # ref: https://docs.cilium.io/en/stable/observability/metrics/
-  metrics: ~
+  metrics:
+    - +cilium_bpf_map_pressure
 
 # -- Grafana dashboards for cilium-agent
 # grafana can import dashboards based on the label and value
@@ -1813,7 +1822,7 @@ prometheus:
 dashboards:
   enabled: false
   label: grafana_dashboard
-  namespace: ~
+  namespace: ""
   labelValue: "1"
   annotations: {}
 
@@ -1824,7 +1833,7 @@ proxy:
     # -- Deprecated in favor of envoy.prometheus.enabled
     enabled: true
     # -- Deprecated in favor of envoy.prometheus.port
-    port: ~
+    port: ""
   # -- Regular expression matching compatible Istio sidecar istio-proxy
   # container image names
   sidecarImageRegex: "cilium/istio_proxy"
@@ -1852,7 +1861,7 @@ envoy:
 
   # -- Envoy container image.
   image:
-    override: ~
+    override: ""
     repository: "quay.io/cilium/cilium-envoy"
     tag: "v1.26.6-ad82c7c56e88989992fd25d8d67747de865c823b"
     pullPolicy: "${PULL_POLICY}"
@@ -1984,11 +1993,11 @@ envoy:
     #   effect: "NoSchedule|PreferNoSchedule|NoExecute(1.6 only)"
 
   # -- The priority class to use for cilium-envoy.
-  priorityClassName: ~
+  priorityClassName: ""
 
   # -- DNS policy for Cilium envoy pods.
   # Ref: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pod-s-dns-policy
-  dnsPolicy: ~
+  dnsPolicy: ""
 
   prometheus:
     # -- Enable prometheus metrics for cilium-envoy
@@ -2013,7 +2022,7 @@ envoy:
           targetLabel: node
           replacement: ${1}
       # -- Metrics relabeling configs for the ServiceMonitor cilium-envoy
-      metricRelabelings: ~
+      metricRelabelings: []
     # -- Serve prometheus metrics for cilium-envoy on the configured port
     port: "9964"
 
@@ -2144,11 +2153,9 @@ etcd:
 
   # -- cilium-etcd-operator image.
   image:
-    override: ~
+    override: ""
     repository: "${CILIUM_ETCD_OPERATOR_REPO}"
     tag: "${CILIUM_ETCD_OPERATOR_VERSION}"
-    digest: "${CILIUM_ETCD_OPERATOR_DIGEST}"
-    useDigest: true
     pullPolicy: "${PULL_POLICY}"
 
   # -- The priority class to use for cilium-etcd-operator
@@ -2199,9 +2206,9 @@ etcd:
     enabled: false
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-    minAvailable: null
+    # minAvailable: null
     # -- Maximum number/percentage of pods that may be made unavailable
-    maxUnavailable: 1
+    maxUnavailable: "1"
 
   # -- cilium-etcd-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2249,7 +2256,7 @@ operator:
 
   # -- cilium-operator image.
   image:
-    override: ~
+    override: ""
     repository: "${CILIUM_OPERATOR_BASE_REPO}"
     tag: "${CILIUM_VERSION}"
     # operator-generic-digest
@@ -2344,12 +2351,12 @@ operator:
   podDisruptionBudget:
     # -- enable PodDisruptionBudget
     # ref: https://kubernetes.io/docs/concepts/workloads/pods/disruptions/
-    enabled: false
+    enabled: true
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-    minAvailable: null
+    # minAvailable: null
     # -- Maximum number/percentage of pods that may be made unavailable
-    maxUnavailable: 1
+    maxUnavailable: "1"
 
   # -- cilium-operator resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2391,7 +2398,7 @@ operator:
   # -- Enable prometheus metrics for cilium-operator on the configured port at
   # /metrics
   prometheus:
-    enabled: false
+    enabled: true
     port: 9963
     serviceMonitor:
       # -- Enable service monitors.
@@ -2404,9 +2411,9 @@ operator:
       # -- Interval for scrape metrics.
       interval: "10s"
       # -- Relabeling configs for the ServiceMonitor cilium-operator
-      relabelings: ~
+      relabelings: []
       # -- Metrics relabeling configs for the ServiceMonitor cilium-operator
-      metricRelabelings: ~
+      metricRelabelings: []
 
   # -- Grafana dashboards for cilium-operator
   # grafana can import dashboards based on the label and value
@@ -2414,7 +2421,7 @@ operator:
   dashboards:
     enabled: false
     label: grafana_dashboard
-    namespace: ~
+    namespace: ""
     labelValue: "1"
     annotations: {}
 
@@ -2428,7 +2435,7 @@ operator:
   # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
   # from being scheduled to nodes where Cilium is not the default CNI provider.
   # @default -- same as removeNodeTaints
-  setNodeTaints: ~
+  setNodeTaints: false
 
   # -- Set Node condition NetworkUnavailable to 'false' with the reason
   # 'CiliumIsUp' for nodes that have a healthy Cilium pod.
@@ -2447,7 +2454,7 @@ nodeinit:
 
   # -- node-init image.
   image:
-    override: ~
+    override: ""
     repository: "${CILIUM_NODEINIT_REPO}"
     tag: "${CILIUM_NODEINIT_VERSION}"
     pullPolicy: "${PULL_POLICY}"
@@ -2536,7 +2543,7 @@ preflight:
 
   # -- Cilium pre-flight image.
   image:
-    override: ~
+    override: ""
     repository: "${CILIUM_REPO}"
     tag: "${CILIUM_VERSION}"
     # cilium-digest
@@ -2609,9 +2616,9 @@ preflight:
     enabled: false
     # -- Minimum number/percentage of pods that should remain scheduled.
     # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-    minAvailable: null
+    # minAvailable: null
     # -- Maximum number/percentage of pods that may be made unavailable
-    maxUnavailable: 1
+    maxUnavailable: "1"
 
   # -- preflight resource limits & requests
   # ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
@@ -2686,7 +2693,7 @@ clustermesh:
   apiserver:
     # -- Clustermesh API server image.
     image:
-      override: ~
+      override: ""
       repository: "${CLUSTERMESH_APISERVER_REPO}"
       tag: "${CILIUM_VERSION}"
       # clustermesh-apiserver-digest
@@ -2697,11 +2704,9 @@ clustermesh:
     etcd:
       # -- Clustermesh API server etcd image.
       image:
-        override: ~
+        override: ""
         repository: "${ETCD_REPO}"
         tag: "${ETCD_VERSION}"
-        digest: "${ETCD_DIGEST}"
-        useDigest: true
         pullPolicy: "${PULL_POLICY}"
 
       # -- Specifies the resources for etcd container in the apiserver
@@ -2733,7 +2738,7 @@ clustermesh:
 
       # -- KVStoreMesh image.
       image:
-        override: ~
+        override: ""
         repository: "${KVSTOREMESH_REPO}"
         tag: "${CILIUM_VERSION}"
         # kvstoremesh-digest
@@ -2788,10 +2793,10 @@ clustermesh:
       annotations: {}
 
       # -- The externalTrafficPolicy of service used for apiserver access.
-      externalTrafficPolicy:
+      externalTrafficPolicy: Cluster
 
       # -- The internalTrafficPolicy of service used for apiserver access.
-      internalTrafficPolicy:
+      internalTrafficPolicy: Cluster
 
     # -- Number of replicas run for the clustermesh-apiserver deployment.
     replicas: 1
@@ -2827,9 +2832,9 @@ clustermesh:
       enabled: false
       # -- Minimum number/percentage of pods that should remain scheduled.
       # When it's set, maxUnavailable must be disabled by `maxUnavailable: null`
-      minAvailable: null
+      # minAvailable: null
       # -- Maximum number/percentage of pods that may be made unavailable
-      maxUnavailable: 1
+      maxUnavailable: "1"
 
     # -- Resource requests and limits for the clustermesh-apiserver container of the clustermesh-apiserver deployment, such as
     #     resources:
@@ -3010,25 +3015,25 @@ clustermesh:
         # -- Interval for scrape metrics (apiserver metrics)
         interval: "10s"
         # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
-        relabelings: ~
+        relabelings: []
         # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (apiserver metrics)
-        metricRelabelings: ~
+        metricRelabelings: []
 
         kvstoremesh:
           # -- Interval for scrape metrics (KVStoreMesh metrics)
           interval: "10s"
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
-          relabelings: ~
+          relabelings: []
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (KVStoreMesh metrics)
-          metricRelabelings: ~
+          metricRelabelings: []
 
         etcd:
           # -- Interval for scrape metrics (etcd metrics)
           interval: "10s"
           # -- Relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
-          relabelings: ~
+          relabelings: []
           # -- Metrics relabeling configs for the ServiceMonitor clustermesh-apiserver (etcd metrics)
-          metricRelabelings: ~
+          metricRelabelings: []
 
 # -- Configure external workloads support
 externalWorkloads:
@@ -3192,7 +3197,7 @@ authentication:
             # -- Access mode of the SPIRE server data storage
             accessMode: ReadWriteOnce
             # -- StorageClass of the SPIRE server data storage
-            storageClass: null
+            storageClass: ""
           # SPIRE CA configuration
           ca:
             # -- SPIRE CA key type
@@ -3209,7 +3214,7 @@ authentication:
       # Cilium Operator will resolve its address by looking up the clusterIP from Service resource.
       #
       # Example values: 10.0.0.1:8081, spire-server.cilium-spire.svc:8081
-      serverAddress: ~
+      serverAddress: ""
       # -- SPIFFE trust domain to use for fetching certificates
       trustDomain: spiffe.cilium
       # -- SPIRE socket path where the SPIRE delegated api agent is listening
@@ -3219,3 +3224,38 @@ authentication:
       agentSocketPath: /run/spire/sockets/agent/agent.sock
       # -- SPIRE connection timeout
       connectionTimeout: 30s
+eksMode: false
+
+defaultPolicies:
+  enabled: false
+  remove: false
+  # -- Node tolerations for default-policies job scheduling to nodes with taints
+  # ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+  tolerations:
+  - operator: Exists
+
+extraPolicies:
+  allowEgressToCoreDNS:
+    enabled: false
+    namespaces:
+      - giantswarm
+      - kube-system
+
+  allowEgressToProxy:
+    enabled: false
+    httpProxy: ""
+    httpsProxy: ""
+    namespaces:
+      - giantswarm
+      - kube-system
+
+  tolerations:
+    - operator: Exists
+
+# If true, it adds an initContainer to cilium-agent pods that cleans up any legacy kube-proxy iptables rules from the node before running cilium.
+# Only makes sense when `kubeProxyReplacement` is enabled (i.e. not set to 'disabled').
+cleanupKubeProxy: false
+
+global:
+  podSecurityStandards:
+    enforced: false

--- a/install/kubernetes/cilium/values.yaml.tmpl
+++ b/install/kubernetes/cilium/values.yaml.tmpl
@@ -464,7 +464,7 @@ bpf:
   neighMax: 524288
 
   # -- Configure the maximum number of entries in endpoint policy map (per endpoint).
-  policyMapMax: 16384
+  policyMapMax: 65536
 
   # -- (float64) Configure auto-sizing for all BPF maps based on available memory.
   # ref: https://docs.cilium.io/en/stable/network/ebpf/maps/
@@ -544,7 +544,7 @@ cni:
   #  - flannel
   #  - generic-veth
   #  - portmap
-  chainingMode: ""
+  chainingMode: "none"
 
   # -- A CNI network name in to which the Cilium plugin should be added as a chained plugin.
   # This will cause the agent to watch for a CNI network with this network name. When it is
@@ -2435,7 +2435,7 @@ operator:
   # -- Taint nodes where Cilium is scheduled but not running. This prevents pods
   # from being scheduled to nodes where Cilium is not the default CNI provider.
   # @default -- same as removeNodeTaints
-  setNodeTaints: false
+  setNodeTaints: true
 
   # -- Set Node condition NetworkUnavailable to 'false' with the reason
   # 'CiliumIsUp' for nodes that have a healthy Cilium pod.


### PR DESCRIPTION
This PR changes the values to not have any `null` values. I pulled the values either from default values mentioned in the `values.yaml` comments or actual cilium code.

It has been tested in https://github.com/giantswarm/cilium-app/pull/136

This causes the following changes:

In the `cilium-config` ConfigMap, it adds:

```diff
347a348
>   enable-bpf-tproxy: "false"
366a368,390
>   enable-host-legacy-routing: "false"
>   # bpf-auth-map-max specifies the maximum number of entries in the auth map
>   bpf-auth-map-max: "524288"
>   # bpf-ct-global-*-max specifies the maximum number of connections
>   # supported across all endpoints, split by protocol: tcp or other. One pair
>   # of maps uses these values for IPv4 connections, and another pair of maps
>   # use these values for IPv6 connections.
>   #
>   # If these values are modified, then during the next Cilium startup the
>   # tracking of ongoing connections may be disrupted. As a result, reply
>   # packets may be dropped and the load-balancing decisions for established
>   # connections may change.
>   #
>   # For users upgrading from Cilium 1.2 or earlier, to minimize disruption
>   # during the upgrade process, set bpf-ct-global-tcp-max to 1000000.
>   bpf-ct-global-tcp-max: "524288"
>   bpf-ct-global-any-max: "262144"
>   # bpf-nat-global-max specified the maximum number of entries in the
>   # BPF NAT table.
>   bpf-nat-global-max: "524288"
>   # bpf-neigh-global-max specified the maximum number of entries in the
>   # BPF neighbor table.
>   bpf-neigh-global-max: "524288"
418a443
>   enable-bpf-masquerade: "false"
442a468
>   cni-chaining-target: ""
458a485
>   hubble-skip-unknown-cgroup-ids: "true"
462a490,491
>   limit-ipam-api-burst: "20"
>   limit-ipam-api-qps: "4"
```

In the `hubble-relay-config` ConfigMap it changes:

```diff
518c547
<     sort-buffer-len-max:
---
>     sort-buffer-len-max: 100
```