### PR TITLE
[SKIP] Set version to 0.20.0 (for cilium-app)

### DIFF
--- a/install/kubernetes/cilium/Chart.yaml
+++ b/install/kubernetes/cilium/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: cilium
 displayName: Cilium
 home: https://cilium.io/
-version: 1.15.1
+version: 0.20.0
 appVersion: 1.15.1
 kubeVersion: ">= 1.16.0-0"
 icon: https://cdn.jsdelivr.net/gh/cilium/cilium@v1.15/Documentation/images/logo-solo.svg


### PR DESCRIPTION
`[SKIP]` part of the title is for the future cherry-picking.