### PR TITLE
More robust image registry setting

### DIFF
--- a/install/kubernetes/Makefile.values
+++ b/install/kubernetes/Makefile.values
@@ -42,14 +42,14 @@ export CILIUM_ETCD_OPERATOR_DIGEST:=sha256:04b8327f7f992693c2cb483b999041ed8f92e
 export CILIUM_NODEINIT_REPO:=giantswarm/cilium-startup-script
 export CILIUM_NODEINIT_VERSION:=62093c5c233ea914bfa26a10ba41f8780d9b737f
 
-export CILIUM_ENVOY_REPO:=quay.io/cilium/cilium-envoy
+export CILIUM_ENVOY_REPO:=giantswarm/cilium-envoy
 export CILIUM_ENVOY_VERSION:=v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9
 export CILIUM_ENVOY_DIGEST:=sha256:a811830c708296194eaf9cee6c1d22c5f8de3544b7eea6cbdfb810326522a4a2
 
 export HUBBLE_UI_BACKEND_REPO:=giantswarm/hubble-ui-backend
 export HUBBLE_UI_BACKEND_VERSION:=v0.13.0
 export HUBBLE_UI_BACKEND_DIGEST:=sha256:1e7657d997c5a48253bb8dc91ecee75b63018d16ff5e5797e5af367336bc8803
-export HUBBLE_UI_FRONTEND_REPO:=quay.io/cilium/hubble-ui
+export HUBBLE_UI_FRONTEND_REPO:=giantswarm/cilium-hubble-ui
 export HUBBLE_UI_FRONTEND_VERSION:=v0.13.0
 export HUBBLE_UI_FRONTEND_DIGEST:=sha256:7d663dc16538dd6e29061abd1047013a645e6e69c115e008bee9ea9fef9a6666
 

--- a/install/kubernetes/cilium/README.md
+++ b/install/kubernetes/cilium/README.md
@@ -337,7 +337,7 @@ contributors across the globe, there is almost always someone available to help.
 | envoy.extraVolumes | list | `[]` | Additional envoy volumes. |
 | envoy.healthPort | int | `9878` | TCP port for the health API. |
 | envoy.idleTimeoutDurationSeconds | int | `60` | Set Envoy upstream HTTP idle connection timeout seconds. Does not apply to connections with pending requests. Default 60s |
-| envoy.image | object | `{"digest":"sha256:a811830c708296194eaf9cee6c1d22c5f8de3544b7eea6cbdfb810326522a4a2","override":"","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/cilium-envoy","tag":"v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9","useDigest":true}` | Envoy container image. |
+| envoy.image | object | `{"digest":"sha256:a811830c708296194eaf9cee6c1d22c5f8de3544b7eea6cbdfb810326522a4a2","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-envoy","tag":"v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9","useDigest":true}` | Envoy container image. |
 | envoy.livenessProbe.failureThreshold | int | `10` | failure threshold of liveness probe |
 | envoy.livenessProbe.periodSeconds | int | `30` | interval between checks of the liveness probe |
 | envoy.log.format | string | `"[%Y-%m-%d %T.%e][%t][%l][%n] [%g:%#] %v"` | The format string to use for laying out the log message metadata of Envoy. |
@@ -538,7 +538,7 @@ contributors across the globe, there is almost always someone available to help.
 | hubble.ui.frontend.extraEnv | list | `[]` | Additional hubble-ui frontend environment variables. |
 | hubble.ui.frontend.extraVolumeMounts | list | `[]` | Additional hubble-ui frontend volumeMounts. |
 | hubble.ui.frontend.extraVolumes | list | `[]` | Additional hubble-ui frontend volumes. |
-| hubble.ui.frontend.image | object | `{"digest":"sha256:7d663dc16538dd6e29061abd1047013a645e6e69c115e008bee9ea9fef9a6666","override":"","pullPolicy":"IfNotPresent","repository":"quay.io/cilium/hubble-ui","tag":"v0.13.0","useDigest":false}` | Hubble-ui frontend image. |
+| hubble.ui.frontend.image | object | `{"digest":"sha256:7d663dc16538dd6e29061abd1047013a645e6e69c115e008bee9ea9fef9a6666","override":"","pullPolicy":"IfNotPresent","repository":"giantswarm/cilium-hubble-ui","tag":"v0.13.0","useDigest":false}` | Hubble-ui frontend image. |
 | hubble.ui.frontend.resources | object | `{}` | Resource requests and limits for the 'frontend' container of the 'hubble-ui' deployment. |
 | hubble.ui.frontend.securityContext | object | `{}` | Hubble-ui frontend security context. |
 | hubble.ui.frontend.server.ipv6 | object | `{"enabled":true}` | Controls server listener for ipv6 |

--- a/install/kubernetes/cilium/templates/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/_helpers.tpl
@@ -18,11 +18,20 @@ then `include "cilium.image" .Values.image`
 will return `quay.io/cilium/cilium:v1.10.1@abcdefgh`
 */}}
 {{- define "cilium.image" -}}
+{{- if not (kindIs "slice" .) }}
+{{- (fail (printf "required list, but got %q" (kindOf .))) }}
+{{- end }}
+{{- if (ne (len .) 2) }}
+{{- (fail (printf "required list of 2 arguments, but got %d" (len .))) }}
+{{- end }}
+{{- $ := index . 0 }}
+{{- with index . 1 }}
 {{- $digest := (.useDigest | default false) | ternary (printf "@%s" .digest) "" -}}
 {{- if .override -}}
 {{- printf "%s" .override -}}
 {{- else -}}
-{{- printf "%s:%s%s" .repository .tag $digest -}}
+{{- printf "%s/%s:%s%s" $.Values.image.registry .repository .tag $digest -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -87,7 +87,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-agent
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.sleepAfterInit }}
         command:
@@ -398,7 +398,7 @@ spec:
         {{- end }}
       {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /bin/bash
@@ -430,7 +430,7 @@ spec:
       {{- end }}
       initContainers:
       - name: config
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - cilium-dbg
@@ -489,7 +489,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: CGROUP_ROOT
@@ -535,7 +535,7 @@ spec:
               - ALL
           {{- end}}
       - name: apply-sysctl-overwrites
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -584,7 +584,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -609,7 +609,7 @@ spec:
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
       - name: wait-for-node-init
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -629,7 +629,7 @@ spec:
           mountPath: "/tmp/cilium-bootstrap.d"
       {{- end }}
       - name: clean-cilium-state
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /init-container.sh
@@ -701,7 +701,7 @@ spec:
         {{- end }}
       {{- if and .Values.waitForKubeProxy (and (ne $kubeProxyReplacement "strict") (ne $kubeProxyReplacement "true"))  }}
       - name: wait-for-kube-proxy
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -738,7 +738,7 @@ spec:
       {{- end }} # wait-for-kube-proxy
       {{ if and (.Values.cleanupKubeProxy) (not (eq .Values.kubeProxyReplacement "disabled")) }}
       - name: cleanup-kube-proxy-iptables
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: "{{ include "cilium.image" .Values.image }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true
@@ -751,7 +751,7 @@ spec:
       {{- if .Values.cni.install }}
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.image }}"
+        image: {{ include "cilium.image" .Values.image | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - "/install-plugin.sh"

--- a/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-agent/daemonset.yaml
@@ -87,7 +87,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-agent
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- if .Values.sleepAfterInit }}
         command:
@@ -398,7 +398,7 @@ spec:
         {{- end }}
       {{- if .Values.monitor.enabled }}
       - name: cilium-monitor
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /bin/bash
@@ -430,7 +430,7 @@ spec:
       {{- end }}
       initContainers:
       - name: config
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - cilium-dbg
@@ -489,7 +489,7 @@ spec:
       # Required to mount cgroup2 filesystem on the underlying Kubernetes node.
       # We use nsenter command with host's cgroup and mount namespaces enabled.
       - name: mount-cgroup
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: CGROUP_ROOT
@@ -535,7 +535,7 @@ spec:
               - ALL
           {{- end}}
       - name: apply-sysctl-overwrites
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -584,7 +584,7 @@ spec:
       # from a privileged container because the mount propagation bidirectional
       # only works from privileged containers.
       - name: mount-bpf-fs
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -609,7 +609,7 @@ spec:
       {{- end }}
       {{- if and .Values.nodeinit.enabled .Values.nodeinit.bootstrapFile }}
       - name: wait-for-node-init
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -629,7 +629,7 @@ spec:
           mountPath: "/tmp/cilium-bootstrap.d"
       {{- end }}
       - name: clean-cilium-state
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /init-container.sh
@@ -701,7 +701,7 @@ spec:
         {{- end }}
       {{- if and .Values.waitForKubeProxy (and (ne $kubeProxyReplacement "strict") (ne $kubeProxyReplacement "true"))  }}
       - name: wait-for-kube-proxy
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.initResources }}
         resources:
@@ -738,7 +738,7 @@ spec:
       {{- end }} # wait-for-kube-proxy
       {{ if and (.Values.cleanupKubeProxy) (not (eq .Values.kubeProxyReplacement "disabled")) }}
       - name: cleanup-kube-proxy-iptables
-        image: "{{ include "cilium.image" .Values.image }}"
+        image: "{{ include "cilium.image" (list $ .Values.image) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         securityContext:
           privileged: true
@@ -751,7 +751,7 @@ spec:
       {{- if .Values.cni.install }}
       # Install the CNI binaries in an InitContainer so we don't have a writable host mount in the agent
       - name: install-cni-binaries
-        image: {{ include "cilium.image" .Values.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.image) | quote }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - "/install-plugin.sh"

--- a/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-envoy/daemonset.yaml
@@ -62,7 +62,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-envoy
-        image: {{ include "cilium.image" .Values.envoy.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.envoy.image) | quote }}
         imagePullPolicy: {{ .Values.envoy.image.pullPolicy }}
         command:
         - /usr/bin/cilium-envoy-starter

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: node-init
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.nodeinit.image }}"
+          image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           lifecycle:
             {{- if .Values.nodeinit.revertReconfigureKubelet }}

--- a/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-nodeinit/daemonset.yaml
@@ -47,7 +47,7 @@ spec:
       {{- end }}
       containers:
         - name: node-init
-          image: {{ include "cilium.image" .Values.nodeinit.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.nodeinit.image) | quote }}
           imagePullPolicy: {{ .Values.nodeinit.image.pullPolicy }}
           lifecycle:
             {{- if .Values.nodeinit.revertReconfigureKubelet }}

--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -31,6 +31,6 @@ Return cilium operator image
 {{- else -}}
 {{- $cloud := include "cilium.operator.cloud" . }}
 {{- $imageDigest := include "cilium.operator.imageDigestName" . }}
-{{- printf "%s/%s-%s%s:%s%s" .Values.image.registry .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
+{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
 {{- end -}}
 {{- end -}}

--- a/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
+++ b/install/kubernetes/cilium/templates/cilium-operator/_helpers.tpl
@@ -26,11 +26,20 @@
 Return cilium operator image
 */}}
 {{- define "cilium.operator.image" -}}
+{{- if not (kindIs "slice" .) }}
+{{- (fail (printf "required list, but got %q" (kindOf .))) }}
+{{- end }}
+{{- if (ne (len .) 2) }}
+{{- (fail (printf "required list of 2 arguments, but got %d" (len .))) }}
+{{- end }}
+{{- $ := index . 0 }}
+{{- with index . 1 }}
 {{- if .Values.operator.image.override -}}
 {{- printf "%s" .Values.operator.image.override -}}
 {{- else -}}
 {{- $cloud := include "cilium.operator.cloud" . }}
 {{- $imageDigest := include "cilium.operator.imageDigestName" . }}
-{{- printf "%s-%s%s:%s%s" .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
+{{- printf "%s/%s-%s%s:%s%s" $.Values.image.registry .Values.operator.image.repository $cloud .Values.operator.image.suffix .Values.operator.image.tag $imageDigest -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-operator/deployment.yaml
@@ -71,7 +71,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-operator
-        image: {{ include "cilium.operator.image" . | quote }}
+        image: {{ include "cilium.operator.image" (list $ .) | quote }}
         imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
         command:
         - cilium-operator-{{ include "cilium.operator.cloud" . }}

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       initContainers:
         - name: clean-cilium-state
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/echo"]
           args:
@@ -50,7 +50,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
       containers:
         - name: cilium-pre-flight-check
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -106,7 +106,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]

--- a/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/daemonset.yaml
@@ -42,7 +42,7 @@ spec:
       {{- end }}
       initContainers:
         - name: clean-cilium-state
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/echo"]
           args:
@@ -50,7 +50,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
       containers:
         - name: cilium-pre-flight-check
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:
@@ -106,7 +106,7 @@ spec:
           terminationMessagePolicy: FallbackToLogsOnError
         {{- if ne .Values.preflight.tofqdnsPreCache "" }}
         - name: cilium-pre-flight-fqdn-precache
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           name: cilium-pre-flight-fqdn-precache
           command: ["/bin/sh"]

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: cnp-validator
-          image: {{ include "cilium.image" .Values.preflight.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.preflight.image) | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:

--- a/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
+++ b/install/kubernetes/cilium/templates/cilium-preflight/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
         - name: cnp-validator
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.preflight.image }}"
+          image: {{ include "cilium.image" .Values.preflight.image | quote }}
           imagePullPolicy: {{ .Values.preflight.image.pullPolicy }}
           command: ["/bin/sh"]
           args:

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -48,9 +48,10 @@ spec:
       {{- end }}
       initContainers:
       - name: etcd-init
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.clustermesh.apiserver.image }}"
-        imagePullPolicy: {{ .Values.clustermesh.apiserver.etcd.image.pullPolicy }}
-        command: ["/bin/sh", "-c"]
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
+        command:
+        - /usr/bin/clustermesh-apiserver
         args:
         - etcdinit
         {{- if .Values.debug.enabled }}
@@ -92,7 +93,7 @@ spec:
       containers:
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.clustermesh.apiserver.image }}"
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/etcd
@@ -152,7 +153,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       - name: apiserver
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.clustermesh.apiserver.image }}"
+        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/deployment.yaml
@@ -48,7 +48,7 @@ spec:
       {{- end }}
       initContainers:
       - name: etcd-init
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.clustermesh.apiserver.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/clustermesh-apiserver
@@ -93,7 +93,7 @@ spec:
       containers:
       - name: etcd
         # The clustermesh-apiserver container image includes an etcd binary.
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.clustermesh.apiserver.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/etcd
@@ -153,7 +153,7 @@ spec:
           {{- toYaml . | nindent 10 }}
         {{- end }}
       - name: apiserver
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.clustermesh.apiserver.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/clustermesh-apiserver
@@ -240,7 +240,7 @@ spec:
         {{- end }}
       {{- if .Values.clustermesh.apiserver.kvstoremesh.enabled }}
       - name: kvstoremesh
-        image: {{ include "cilium.image" .Values.clustermesh.apiserver.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.clustermesh.apiserver.image) | quote }}
         imagePullPolicy: {{ .Values.clustermesh.apiserver.image.pullPolicy }}
         command:
         - /usr/bin/clustermesh-apiserver

--- a/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/clustermesh-apiserver/tls-cronjob/_job-spec.tpl
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.certgen.image }}"
+          image: {{ include "cilium.image" .Values.certgen.image | quote }}
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -94,7 +94,7 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.etcd.image }}"
+        image: {{ include "cilium.image" .Values.etcd.image | quote }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
         terminationMessagePolicy: FallbackToLogsOnError

--- a/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
+++ b/install/kubernetes/cilium/templates/etcd-operator/cilium-etcd-operator-deployment.yaml
@@ -94,7 +94,7 @@ spec:
           value: "revision"
         - name: CILIUM_ETCD_META_ETCD_AUTO_COMPACTION_RETENTION
           value: "25000"
-        image: {{ include "cilium.image" .Values.etcd.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.etcd.image) | quote }}
         imagePullPolicy: {{ .Values.etcd.image.pullPolicy }}
         name: cilium-etcd-operator
         terminationMessagePolicy: FallbackToLogsOnError

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.hubble.relay.image }}"
+          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-relay/deployment.yaml
@@ -53,7 +53,7 @@ spec:
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          image: {{ include "cilium.image" .Values.hubble.relay.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.hubble.relay.image) | quote }}
           imagePullPolicy: {{ .Values.hubble.relay.image.pullPolicy }}
           command:
             - hubble-relay

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
       - name: frontend
-        image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.hubble.ui.frontend.image) | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
         ports:
         - name: http
@@ -91,7 +91,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
       - name: backend
-        image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.hubble.ui.backend.image) | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
         env:
         - name: EVENTS_SERVER_PORT

--- a/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
+++ b/install/kubernetes/cilium/templates/hubble-ui/deployment.yaml
@@ -55,7 +55,7 @@ spec:
       {{- end }}
       containers:
       - name: frontend
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.hubble.ui.frontend.image }}"
+        image: {{ include "cilium.image" .Values.hubble.ui.frontend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.frontend.image.pullPolicy }}
         ports:
         - name: http
@@ -91,7 +91,7 @@ spec:
           {{- toYaml . | trim | nindent 10 }}
         {{- end }}
       - name: backend
-        image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.hubble.ui.backend.image }}"
+        image: {{ include "cilium.image" .Values.hubble.ui.backend.image | quote }}
         imagePullPolicy: {{ .Values.hubble.ui.backend.image.pullPolicy }}
         env:
         - name: EVENTS_SERVER_PORT

--- a/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
+++ b/install/kubernetes/cilium/templates/hubble/tls-cronjob/_job-spec.tpl
@@ -11,7 +11,7 @@ spec:
     spec:
       containers:
         - name: certgen
-          image: "{{ .Values.image.registry }}/{{ include "cilium.image" .Values.certgen.image }}"
+          image: {{ include "cilium.image" .Values.certgen.image | quote }}
           imagePullPolicy: {{ .Values.certgen.image.pullPolicy }}
           command:
             - "/usr/bin/cilium-certgen"

--- a/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
+++ b/install/kubernetes/cilium/templates/spire/agent/daemonset.yaml
@@ -41,7 +41,7 @@ spec:
       {{- end }}
       initContainers:
         - name: init
-          image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.initImage | quote }}
+          image: {{ include "cilium.image" (list $ .Values.authentication.mutual.spire.install.initImage) | quote }}
           imagePullPolicy: {{ .Values.authentication.mutual.spire.install.initImage.pullPolicy }}
           command:
             - /bin/sh
@@ -53,7 +53,7 @@ spec:
           {{- if eq (typeOf .Values.authentication.mutual.spire.install.agent.image) "string" }}
           image: {{ .Values.authentication.mutual.spire.install.agent.image }}
           {{- else }}
-          image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.agent.image | quote }}
+          image: {{ include "cilium.image" (list $ .Values.authentication.mutual.spire.install.agent.image) | quote }}
           imagePullPolicy: {{ .Values.authentication.mutual.spire.install.agent.image.pullPolicy }}
           {{- end }}
           args: ["-config", "/run/spire/config/agent.conf"]

--- a/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
+++ b/install/kubernetes/cilium/templates/spire/server/statefulset.yaml
@@ -44,7 +44,7 @@ spec:
       {{- end }}
       containers:
       - name: cilium-init
-        image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.initImage | quote }}
+        image: {{ include "cilium.image" (list $ .Values.authentication.mutual.spire.install.initImage) | quote }}
         imagePullPolicy: {{ .Values.authentication.mutual.spire.install.initImage.pullPolicy }}
         command:
           - /bin/sh
@@ -55,7 +55,7 @@ spec:
         {{- if eq (typeOf .Values.authentication.mutual.spire.install.server.image) "string" }}
         image: {{ .Values.authentication.mutual.spire.install.server.image }}
         {{- else }}
-        image: {{ include "cilium.image" .Values.authentication.mutual.spire.install.server.image | quote }}
+        image: {{ include "cilium.image" (list $ .Values.authentication.mutual.spire.install.server.image) | quote }}
         imagePullPolicy: {{ .Values.authentication.mutual.spire.install.server.image.pullPolicy }}
         {{- end }}
         args:

--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -1507,7 +1507,7 @@ hubble:
       # -- Hubble-ui frontend image.
       image:
         override: ""
-        repository: "quay.io/cilium/hubble-ui"
+        repository: "giantswarm/cilium-hubble-ui"
         tag: "v0.13.0"
         digest: "sha256:7d663dc16538dd6e29061abd1047013a645e6e69c115e008bee9ea9fef9a6666"
         useDigest: false
@@ -2072,7 +2072,7 @@ envoy:
   # -- Envoy container image.
   image:
     override: ""
-    repository: "quay.io/cilium/cilium-envoy"
+    repository: "giantswarm/cilium-envoy"
     tag: "v1.27.3-713b673cccf1af661efd75ca20532336517ddcb9"
     pullPolicy: "IfNotPresent"
     digest: "sha256:a811830c708296194eaf9cee6c1d22c5f8de3544b7eea6cbdfb810326522a4a2"


### PR DESCRIPTION
This isn't maybe simpler, but fails with meaningful message if image is not formatted as expected.

Changes to `include` were made with `sed` and `zsh`:

```
$ sed --version | head -n 1
sed (GNU sed) 4.8

$ sed -E -i 's/(\{\{\s*include\s+"cilium.image"\s+)(\S+)(.*}\})/\1(list $ \2)\3/g' install/kubernetes/cilium/templates/**/*.yaml
```

Verification:

```
$ helm template -n asdf-ns install/kubernetes/cilium  | grep image:
  sidecar-istio-proxy-image: "cilium/istio_proxy"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium-operator-generic:v1.15.1"
          image: "gsoci.azurecr.io/giantswarm/hubble-relay:v1.15.1"
        image: "gsoci.azurecr.io/giantswarm/cilium-hubble-ui:v0.13.0"
        image: "gsoci.azurecr.io/giantswarm/hubble-ui-backend:v0.13.0"
```