### PR TITLE
Enable SocketLB only for hostNamespace

### DIFF
--- a/install/kubernetes/cilium/values.yaml
+++ b/install/kubernetes/cilium/values.yaml
@@ -965,7 +965,7 @@ socketLB:
   enabled: false
 
   # -- Disable socket lb for non-root ns. This is used to enable Istio routing rules.
-  # hostNamespaceOnly: false
+  hostNamespaceOnly: true
 
 # -- Configure certificate generation for Hubble integration.
 # If hubble.tls.auto.method=cronJob, these values are used


### PR DESCRIPTION
This is an acceptable trade-off between performance and stability, provided that socketlb on UDP connections could cause termination issues.

Also allows identity-based policies to be applied correctly on service meshes.