### PR TITLE
Support CAPA clusters for ENI mode

### DIFF
--- a/install/kubernetes/cilium/templates/cilium-cni-configmap.yaml
+++ b/install/kubernetes/cilium/templates/cilium-cni-configmap.yaml
@@ -48,15 +48,15 @@ data:
               {{- if and (not .Values.eksMode) (eq .Values.provider "capa") -}}
               {{/*
                   For CAPA EC2-based clusters (https://github.com/giantswarm/cluster-aws)
-
-                  The full ENI mode feature is in development (https://github.com/giantswarm/roadmap/issues/2563). Open TODOs:
-
-                  - Once a secondary VPC CIDR is added, this must be set as well for the below subnet tags selector: `"sigs.k8s.io/cluster-api-provider-aws/association": "secondary",`
-                  - And `"security-group-tags": [...]` should be added once there's a specific pod security group.
               */}}
               "first-interface-index": 1,
+              "security-group-tags": {
+                "kubernetes.io/cluster/{{ .Values.cluster.name }}": "owned",
+                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary"
+              },
               "subnet-tags": {
                 "sigs.k8s.io/cluster-api-provider-aws/cluster/{{ .Values.cluster.name }}": "owned",
+                "sigs.k8s.io/cluster-api-provider-aws/association": "secondary",
                 "sigs.k8s.io/cluster-api-provider-aws/role": "private"
               }
               {{- end }}


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/2563

From https://github.com/giantswarm/cilium-app/pull/179#issuecomment-2071866868, I understand that the change should first go _into this repo_ and then get synced to `cilium-app`.